### PR TITLE
feat: implement Create Habit multi-step wizard

### DIFF
--- a/app/src/main/kotlin/com/getaltair/kairos/KairosApp.kt
+++ b/app/src/main/kotlin/com/getaltair/kairos/KairosApp.kt
@@ -3,6 +3,7 @@ package com.getaltair.kairos
 import android.app.Application
 import com.getaltair.kairos.core.di.useCaseModule
 import com.getaltair.kairos.data.di.dataModule
+import com.getaltair.kairos.feature.habit.di.habitModule
 import com.getaltair.kairos.feature.today.di.todayModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -23,7 +24,8 @@ class KairosApp : Application() {
             modules(
                 dataModule,
                 useCaseModule,
-                todayModule
+                todayModule,
+                habitModule
             )
         }
     }

--- a/app/src/main/kotlin/com/getaltair/kairos/navigation/KairosNavGraph.kt
+++ b/app/src/main/kotlin/com/getaltair/kairos/navigation/KairosNavGraph.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.getaltair.kairos.feature.habit.CreateHabitScreen
 import com.getaltair.kairos.feature.today.TodayScreen
 
 @Composable
@@ -14,10 +15,13 @@ fun KairosNavGraph() {
         startDestination = "today"
     ) {
         composable("today") {
-            TodayScreen()
+            TodayScreen(onAddHabit = { navController.navigate("createHabit") })
         }
-        composable("habit") {
-            // TODO: Step 6 - Habit creation screen
+        composable("createHabit") {
+            CreateHabitScreen(
+                onBack = { navController.popBackStack() },
+                onCreated = { navController.popBackStack() }
+            )
         }
         composable("settings") {
             // TODO: Settings screen

--- a/feature/habit/build.gradle.kts
+++ b/feature/habit/build.gradle.kts
@@ -16,10 +16,16 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(platform(libs.koin.bom))
     implementation(libs.koin.core)
     implementation(libs.koin.androidx.compose)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.timber)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/CreateHabitScreen.kt
+++ b/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/CreateHabitScreen.kt
@@ -1,0 +1,163 @@
+package com.getaltair.kairos.feature.habit
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.getaltair.kairos.feature.habit.steps.AnchorStep
+import com.getaltair.kairos.feature.habit.steps.CategoryStep
+import com.getaltair.kairos.feature.habit.steps.NameStep
+import com.getaltair.kairos.feature.habit.steps.OptionsStep
+import org.koin.androidx.compose.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateHabitScreen(onBack: () -> Unit, onCreated: () -> Unit, viewModel: CreateHabitViewModel = koinViewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.isCreated) {
+        if (uiState.isCreated) {
+            onCreated()
+        }
+    }
+
+    LaunchedEffect(uiState.creationError) {
+        uiState.creationError?.let { error ->
+            snackbarHostState.showSnackbar(message = error)
+            viewModel.clearCreationError()
+        }
+    }
+
+    val stepNumber = uiState.currentStep.ordinal + 1
+    val stepTitle = when (uiState.currentStep) {
+        WizardStep.NAME -> "Name your habit"
+        WizardStep.ANCHOR -> "Choose an anchor"
+        WizardStep.CATEGORY -> "Choose a category"
+        WizardStep.OPTIONS -> "Optional details"
+    }
+
+    Scaffold(
+        topBar = {
+            Column {
+                TopAppBar(
+                    navigationIcon = {
+                        IconButton(
+                            onClick = {
+                                if (uiState.currentStep == WizardStep.NAME) {
+                                    onBack()
+                                } else {
+                                    viewModel.goToPreviousStep()
+                                }
+                            }
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back"
+                            )
+                        }
+                    },
+                    title = {
+                        Text(text = "$stepTitle ($stepNumber/${WizardStep.entries.size})")
+                    }
+                )
+                if (uiState.isCreating) {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+            ) {
+                AnimatedContent(
+                    targetState = uiState.currentStep,
+                    transitionSpec = {
+                        slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+                    },
+                    label = "wizard_step"
+                ) { step ->
+                    when (step) {
+                        WizardStep.NAME -> NameStep(
+                            name = uiState.name,
+                            nameError = uiState.nameError,
+                            onNameChanged = viewModel::onNameChanged,
+                            onContinue = viewModel::goToNextStep
+                        )
+
+                        WizardStep.ANCHOR -> AnchorStep(
+                            anchorType = uiState.anchorType,
+                            anchorBehavior = uiState.anchorBehavior,
+                            anchorTime = uiState.anchorTime,
+                            anchorError = uiState.anchorError,
+                            onAnchorTypeSelected = viewModel::onAnchorTypeSelected,
+                            onAnchorBehaviorChanged = viewModel::onAnchorBehaviorChanged,
+                            onAnchorTimeChanged = viewModel::onAnchorTimeChanged,
+                            onContinue = viewModel::goToNextStep
+                        )
+
+                        WizardStep.CATEGORY -> CategoryStep(
+                            selected = uiState.category,
+                            categoryError = uiState.categoryError,
+                            onCategorySelected = viewModel::onCategorySelected,
+                            onContinue = viewModel::goToNextStep
+                        )
+
+                        WizardStep.OPTIONS -> OptionsStep(
+                            estimatedSeconds = uiState.estimatedSeconds,
+                            microVersion = uiState.microVersion,
+                            icon = uiState.icon,
+                            color = uiState.color,
+                            frequency = uiState.frequency,
+                            activeDays = uiState.activeDays,
+                            isCreating = uiState.isCreating,
+                            onEstimatedSecondsChanged = viewModel::onEstimatedSecondsChanged,
+                            onMicroVersionChanged = viewModel::onMicroVersionChanged,
+                            onIconSelected = viewModel::onIconSelected,
+                            onColorSelected = viewModel::onColorSelected,
+                            onFrequencySelected = viewModel::onFrequencySelected,
+                            onActiveDaysChanged = viewModel::onActiveDaysChanged,
+                            onCreateHabit = viewModel::createHabit
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/CreateHabitUiState.kt
+++ b/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/CreateHabitUiState.kt
@@ -1,0 +1,29 @@
+package com.getaltair.kairos.feature.habit
+
+import com.getaltair.kairos.domain.enums.AnchorType
+import com.getaltair.kairos.domain.enums.HabitCategory
+import com.getaltair.kairos.domain.enums.HabitFrequency
+import java.time.DayOfWeek
+
+enum class WizardStep { NAME, ANCHOR, CATEGORY, OPTIONS }
+
+data class CreateHabitUiState(
+    val currentStep: WizardStep = WizardStep.NAME,
+    val name: String = "",
+    val nameError: String? = null,
+    val anchorType: AnchorType = AnchorType.AfterBehavior,
+    val anchorBehavior: String = "",
+    val anchorError: String? = null,
+    val anchorTime: String? = null,
+    val category: HabitCategory? = null,
+    val categoryError: String? = null,
+    val estimatedSeconds: Int = 300,
+    val microVersion: String = "",
+    val icon: String? = null,
+    val color: String? = null,
+    val frequency: HabitFrequency = HabitFrequency.Daily,
+    val activeDays: Set<DayOfWeek> = emptySet(),
+    val isCreating: Boolean = false,
+    val creationError: String? = null,
+    val isCreated: Boolean = false
+)

--- a/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/CreateHabitViewModel.kt
+++ b/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/CreateHabitViewModel.kt
@@ -1,0 +1,215 @@
+package com.getaltair.kairos.feature.habit
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.getaltair.kairos.domain.common.Result
+import com.getaltair.kairos.domain.entity.Habit
+import com.getaltair.kairos.domain.enums.AnchorType
+import com.getaltair.kairos.domain.enums.HabitCategory
+import com.getaltair.kairos.domain.enums.HabitFrequency
+import com.getaltair.kairos.domain.enums.HabitPhase
+import com.getaltair.kairos.domain.enums.HabitStatus
+import com.getaltair.kairos.domain.usecase.CreateHabitUseCase
+import java.time.DayOfWeek
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class CreateHabitViewModel(private val createHabitUseCase: CreateHabitUseCase) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CreateHabitUiState())
+    val uiState: StateFlow<CreateHabitUiState> = _uiState.asStateFlow()
+
+    fun onNameChanged(name: String) {
+        _uiState.update { it.copy(name = name, nameError = null) }
+    }
+
+    fun onAnchorTypeSelected(type: AnchorType) {
+        _uiState.update {
+            it.copy(
+                anchorType = type,
+                anchorBehavior = "",
+                anchorTime = null,
+                anchorError = null
+            )
+        }
+    }
+
+    fun onAnchorBehaviorChanged(text: String) {
+        _uiState.update { it.copy(anchorBehavior = text, anchorError = null) }
+    }
+
+    fun onAnchorTimeChanged(time: String) {
+        _uiState.update {
+            it.copy(
+                anchorTime = time,
+                anchorBehavior = time,
+                anchorError = null
+            )
+        }
+    }
+
+    fun onCategorySelected(category: HabitCategory) {
+        _uiState.update { it.copy(category = category, categoryError = null) }
+    }
+
+    fun onEstimatedSecondsChanged(seconds: Int) {
+        _uiState.update { it.copy(estimatedSeconds = seconds) }
+    }
+
+    fun onMicroVersionChanged(text: String) {
+        _uiState.update { it.copy(microVersion = text) }
+    }
+
+    fun onIconSelected(icon: String?) {
+        _uiState.update { it.copy(icon = icon) }
+    }
+
+    fun onColorSelected(color: String?) {
+        _uiState.update { it.copy(color = color) }
+    }
+
+    fun onFrequencySelected(freq: HabitFrequency) {
+        _uiState.update {
+            val activeDays = if (freq is HabitFrequency.Custom) it.activeDays else emptySet()
+            it.copy(frequency = freq, activeDays = activeDays)
+        }
+    }
+
+    fun onActiveDaysChanged(days: Set<DayOfWeek>) {
+        _uiState.update { it.copy(activeDays = days) }
+    }
+
+    fun goToNextStep() {
+        val state = _uiState.value
+        when (state.currentStep) {
+            WizardStep.NAME -> {
+                when {
+                    state.name.isBlank() -> {
+                        _uiState.update { it.copy(nameError = "Name is required") }
+                        return
+                    }
+
+                    state.name.length > 100 -> {
+                        _uiState.update { it.copy(nameError = "Name must be 100 characters or fewer") }
+                        return
+                    }
+                }
+                _uiState.update { it.copy(currentStep = WizardStep.ANCHOR) }
+            }
+
+            WizardStep.ANCHOR -> {
+                when {
+                    state.anchorType !is AnchorType.AtTime && state.anchorBehavior.isBlank() -> {
+                        _uiState.update { it.copy(anchorError = "Please describe the anchor behavior") }
+                        return
+                    }
+
+                    state.anchorType is AnchorType.AtTime && state.anchorTime == null -> {
+                        _uiState.update { it.copy(anchorError = "Please set a time") }
+                        return
+                    }
+                }
+                _uiState.update { it.copy(currentStep = WizardStep.CATEGORY) }
+            }
+
+            WizardStep.CATEGORY -> {
+                if (state.category == null) {
+                    _uiState.update { it.copy(categoryError = "Please select a category") }
+                    return
+                }
+                _uiState.update { it.copy(currentStep = WizardStep.OPTIONS) }
+            }
+
+            WizardStep.OPTIONS -> {
+                // No-op: Create button handles submission
+            }
+        }
+    }
+
+    fun goToPreviousStep() {
+        val state = _uiState.value
+        when (state.currentStep) {
+            WizardStep.NAME -> {
+                // No-op: already on first step
+            }
+
+            WizardStep.ANCHOR -> _uiState.update { it.copy(currentStep = WizardStep.NAME) }
+
+            WizardStep.CATEGORY -> _uiState.update { it.copy(currentStep = WizardStep.ANCHOR) }
+
+            WizardStep.OPTIONS -> _uiState.update { it.copy(currentStep = WizardStep.CATEGORY) }
+        }
+    }
+
+    fun createHabit() {
+        if (_uiState.value.isCreating) return
+
+        val state = _uiState.value
+
+        val category = state.category
+        if (category == null) {
+            Timber.e("createHabit called with null category")
+            _uiState.update { it.copy(creationError = "Please select a category before creating your habit.") }
+            return
+        }
+
+        val activeDays = if (state.frequency is HabitFrequency.Custom) state.activeDays else null
+
+        if (state.frequency is HabitFrequency.Custom && activeDays.isNullOrEmpty()) {
+            _uiState.update { it.copy(creationError = "Please select at least one day for custom frequency") }
+            return
+        }
+
+        val habit = Habit(
+            name = state.name,
+            anchorBehavior = state.anchorBehavior,
+            anchorType = state.anchorType,
+            timeWindowStart = state.anchorTime,
+            category = category,
+            frequency = state.frequency,
+            activeDays = activeDays,
+            estimatedSeconds = state.estimatedSeconds,
+            microVersion = state.microVersion.ifBlank { null },
+            icon = state.icon,
+            color = state.color,
+            allowPartialCompletion = true,
+            phase = HabitPhase.ONBOARD,
+            status = HabitStatus.Active,
+            lapseThresholdDays = 3,
+            relapseThresholdDays = 7
+        )
+
+        _uiState.update { it.copy(isCreating = true, creationError = null) }
+
+        viewModelScope.launch {
+            try {
+                when (val result = createHabitUseCase(habit)) {
+                    is Result.Success -> {
+                        _uiState.update { it.copy(isCreating = false, isCreated = true) }
+                    }
+
+                    is Result.Error -> {
+                        Timber.e(result.cause, "Failed to create habit: %s", result.message)
+                        _uiState.update { it.copy(isCreating = false, creationError = result.message) }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Unexpected error creating habit")
+                _uiState.update {
+                    it.copy(isCreating = false, creationError = "Something went wrong. Please try again.")
+                }
+            }
+        }
+    }
+
+    fun clearCreationError() {
+        _uiState.update { it.copy(creationError = null) }
+    }
+}

--- a/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/di/HabitModule.kt
+++ b/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/di/HabitModule.kt
@@ -1,0 +1,9 @@
+package com.getaltair.kairos.feature.habit.di
+
+import com.getaltair.kairos.feature.habit.CreateHabitViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+val habitModule = module {
+    viewModelOf(::CreateHabitViewModel)
+}

--- a/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/steps/AnchorStep.kt
+++ b/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/steps/AnchorStep.kt
@@ -1,0 +1,192 @@
+package com.getaltair.kairos.feature.habit.steps
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PrimaryScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.getaltair.kairos.domain.enums.AnchorType
+
+private val anchorTypes = listOf(
+    AnchorType.AfterBehavior,
+    AnchorType.BeforeBehavior,
+    AnchorType.AtLocation,
+    AnchorType.AtTime
+)
+
+private val anchorTabLabels = listOf(
+    "After I...",
+    "Before I...",
+    "When I arrive at...",
+    "At a specific time"
+)
+
+private val afterPresets = listOf(
+    "Wake up",
+    "Brush my teeth",
+    "Have breakfast",
+    "Get to work"
+)
+
+private val beforePresets = listOf(
+    "Go to bed",
+    "Leave for work",
+    "Eat dinner"
+)
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun AnchorStep(
+    anchorType: AnchorType,
+    anchorBehavior: String,
+    anchorTime: String?,
+    anchorError: String?,
+    onAnchorTypeSelected: (AnchorType) -> Unit,
+    onAnchorBehaviorChanged: (String) -> Unit,
+    onAnchorTimeChanged: (String) -> Unit,
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val selectedTabIndex = when (anchorType) {
+        is AnchorType.AfterBehavior -> 0
+        is AnchorType.BeforeBehavior -> 1
+        is AnchorType.AtLocation -> 2
+        is AnchorType.AtTime -> 3
+    }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "When will you do this?",
+            style = MaterialTheme.typography.headlineSmall
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        PrimaryScrollableTabRow(selectedTabIndex = selectedTabIndex) {
+            anchorTabLabels.forEachIndexed { index, label ->
+                Tab(
+                    selected = selectedTabIndex == index,
+                    onClick = { onAnchorTypeSelected(anchorTypes[index]) },
+                    text = { Text(label) }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        when (anchorType) {
+            is AnchorType.AfterBehavior -> {
+                BehaviorPresetContent(
+                    presets = afterPresets,
+                    anchorBehavior = anchorBehavior,
+                    placeholder = "Or type your own...",
+                    onPresetSelected = onAnchorBehaviorChanged,
+                    onTextChanged = onAnchorBehaviorChanged
+                )
+            }
+
+            is AnchorType.BeforeBehavior -> {
+                BehaviorPresetContent(
+                    presets = beforePresets,
+                    anchorBehavior = anchorBehavior,
+                    placeholder = "Or type your own...",
+                    onPresetSelected = onAnchorBehaviorChanged,
+                    onTextChanged = onAnchorBehaviorChanged
+                )
+            }
+
+            is AnchorType.AtLocation -> {
+                OutlinedTextField(
+                    value = anchorBehavior,
+                    onValueChange = onAnchorBehaviorChanged,
+                    label = { Text("Location") },
+                    placeholder = { Text("e.g. Home, Work, Gym...") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+            }
+
+            is AnchorType.AtTime -> {
+                OutlinedTextField(
+                    value = anchorTime ?: "",
+                    onValueChange = { onAnchorTimeChanged(it) },
+                    label = { Text("Time") },
+                    placeholder = { Text("e.g. 7:00 AM") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+            }
+        }
+
+        if (anchorError != null) {
+            Text(
+                text = anchorError,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        val isContinueEnabled = when (anchorType) {
+            is AnchorType.AtTime -> !anchorTime.isNullOrBlank()
+            else -> anchorBehavior.isNotBlank()
+        }
+
+        Button(
+            onClick = onContinue,
+            enabled = isContinueEnabled,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Continue")
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun BehaviorPresetContent(
+    presets: List<String>,
+    anchorBehavior: String,
+    placeholder: String,
+    onPresetSelected: (String) -> Unit,
+    onTextChanged: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        FlowRow(modifier = Modifier.fillMaxWidth()) {
+            presets.forEach { preset ->
+                FilterChip(
+                    selected = anchorBehavior == preset,
+                    onClick = { onPresetSelected(preset) },
+                    label = { Text(preset) },
+                    modifier = Modifier.padding(end = 8.dp, bottom = 4.dp)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = anchorBehavior,
+            onValueChange = onTextChanged,
+            placeholder = { Text(placeholder) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true
+        )
+    }
+}

--- a/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/steps/CategoryStep.kt
+++ b/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/steps/CategoryStep.kt
@@ -1,0 +1,132 @@
+package com.getaltair.kairos.feature.habit.steps
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.getaltair.kairos.domain.enums.HabitCategory
+
+private val allCategories: List<HabitCategory> = listOf(
+    HabitCategory.Morning,
+    HabitCategory.Afternoon,
+    HabitCategory.Evening,
+    HabitCategory.Anytime,
+    HabitCategory.Departure
+)
+
+private fun categoryDescription(category: HabitCategory): String = when (category) {
+    is HabitCategory.Morning -> "Before noon"
+    is HabitCategory.Afternoon -> "12 PM - 6 PM"
+    is HabitCategory.Evening -> "After 6 PM"
+    is HabitCategory.Anytime -> "No specific time"
+    is HabitCategory.Departure -> "Shown on doorway dashboard"
+}
+
+@Composable
+fun CategoryStep(
+    selected: HabitCategory?,
+    categoryError: String?,
+    onCategorySelected: (HabitCategory) -> Unit,
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "Choose a category",
+            style = MaterialTheme.typography.headlineSmall
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            allCategories.chunked(2).forEach { rowCategories ->
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    rowCategories.forEach { category ->
+                        val isSelected = selected == category
+                        if (isSelected) {
+                            ElevatedCard(
+                                onClick = { onCategorySelected(category) },
+                                colors = CardDefaults.elevatedCardColors(
+                                    containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
+                                ),
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                CategoryCardContent(category = category)
+                            }
+                        } else {
+                            OutlinedCard(
+                                onClick = { onCategorySelected(category) },
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                CategoryCardContent(category = category)
+                            }
+                        }
+                    }
+                    // Fill remaining space if odd number of items in row
+                    if (rowCategories.size == 1) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+
+        if (categoryError != null) {
+            Text(
+                text = categoryError,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = onContinue,
+            enabled = selected != null,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Continue")
+        }
+    }
+}
+
+@Composable
+private fun CategoryCardContent(category: HabitCategory, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(16.dp)
+    ) {
+        Text(
+            text = category.emoji,
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = category.displayName,
+            style = MaterialTheme.typography.titleSmall
+        )
+        Text(
+            text = categoryDescription(category),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/steps/NameStep.kt
+++ b/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/steps/NameStep.kt
@@ -1,0 +1,114 @@
+package com.getaltair.kairos.feature.habit.steps
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.unit.dp
+
+private val nameSuggestions = listOf(
+    "Take medication",
+    "Exercise",
+    "Read",
+    "Meditate",
+    "Journal",
+    "Drink water"
+)
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun NameStep(
+    name: String,
+    nameError: String?,
+    onNameChanged: (String) -> Unit,
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "What do you want to do?",
+            style = MaterialTheme.typography.headlineSmall
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = name,
+            onValueChange = { if (it.length <= 100) onNameChanged(it) },
+            label = { Text("Habit name") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester),
+            singleLine = true,
+            isError = nameError != null
+        )
+
+        Text(
+            text = "${name.length}/100",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp)
+        )
+
+        if (nameError != null) {
+            Text(
+                text = nameError,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 2.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Common habits:",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            nameSuggestions.forEach { suggestion ->
+                SuggestionChip(
+                    onClick = { onNameChanged(suggestion) },
+                    label = { Text(suggestion) },
+                    modifier = Modifier.padding(end = 8.dp, bottom = 4.dp)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = onContinue,
+            enabled = name.isNotBlank() && name.length <= 100,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Continue")
+        }
+    }
+}

--- a/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/steps/OptionsStep.kt
+++ b/feature/habit/src/main/kotlin/com/getaltair/kairos/feature/habit/steps/OptionsStep.kt
@@ -1,0 +1,327 @@
+package com.getaltair.kairos.feature.habit.steps
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.Book
+import androidx.compose.material.icons.filled.DirectionsRun
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.LocalDrink
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material.icons.filled.SelfImprovement
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.getaltair.kairos.domain.enums.HabitFrequency
+import java.time.DayOfWeek
+
+private data class HabitIcon(val name: String, val vector: ImageVector)
+
+private val habitIcons: List<HabitIcon> = listOf(
+    HabitIcon("fitness", Icons.Filled.FitnessCenter),
+    HabitIcon("run", Icons.Filled.DirectionsRun),
+    HabitIcon("book", Icons.Filled.Book),
+    HabitIcon("meditation", Icons.Filled.SelfImprovement),
+    HabitIcon("journal", Icons.Filled.Edit),
+    HabitIcon("water", Icons.Filled.LocalDrink),
+    HabitIcon("food", Icons.Filled.Restaurant),
+    HabitIcon("sleep", Icons.Filled.Bedtime),
+    HabitIcon("music", Icons.Filled.MusicNote)
+)
+
+private val habitColors: List<Pair<String, Color>> = listOf(
+    "#4CAF50" to Color(0xFF4CAF50),
+    "#2196F3" to Color(0xFF2196F3),
+    "#9C27B0" to Color(0xFF9C27B0),
+    "#FF9800" to Color(0xFFFF9800),
+    "#F44336" to Color(0xFFF44336),
+    "#00BCD4" to Color(0xFF00BCD4),
+    "#FF5722" to Color(0xFFFF5722),
+    "#607D8B" to Color(0xFF607D8B)
+)
+
+private val frequencyOptions: List<HabitFrequency> = listOf(
+    HabitFrequency.Daily,
+    HabitFrequency.Weekdays,
+    HabitFrequency.Weekends,
+    HabitFrequency.Custom
+)
+
+private val daysOfWeek: List<DayOfWeek> = listOf(
+    DayOfWeek.MONDAY,
+    DayOfWeek.TUESDAY,
+    DayOfWeek.WEDNESDAY,
+    DayOfWeek.THURSDAY,
+    DayOfWeek.FRIDAY,
+    DayOfWeek.SATURDAY,
+    DayOfWeek.SUNDAY
+)
+
+private fun dayLabel(day: DayOfWeek): String = when (day) {
+    DayOfWeek.MONDAY -> "Mon"
+    DayOfWeek.TUESDAY -> "Tue"
+    DayOfWeek.WEDNESDAY -> "Wed"
+    DayOfWeek.THURSDAY -> "Thu"
+    DayOfWeek.FRIDAY -> "Fri"
+    DayOfWeek.SATURDAY -> "Sat"
+    DayOfWeek.SUNDAY -> "Sun"
+}
+
+private fun formatDuration(seconds: Int): String {
+    val minutes = seconds / 60
+    return if (minutes == 1) "1 minute" else "$minutes minutes"
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun OptionsStep(
+    estimatedSeconds: Int,
+    microVersion: String,
+    icon: String?,
+    color: String?,
+    frequency: HabitFrequency,
+    activeDays: Set<DayOfWeek>,
+    isCreating: Boolean,
+    onEstimatedSecondsChanged: (Int) -> Unit,
+    onMicroVersionChanged: (String) -> Unit,
+    onIconSelected: (String?) -> Unit,
+    onColorSelected: (String?) -> Unit,
+    onFrequencySelected: (HabitFrequency) -> Unit,
+    onActiveDaysChanged: (Set<DayOfWeek>) -> Unit,
+    onCreateHabit: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "Optional details",
+            style = MaterialTheme.typography.headlineSmall
+        )
+
+        Text(
+            text = "All fields have sensible defaults",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Duration section
+        Text(
+            text = "Estimated duration",
+            style = MaterialTheme.typography.labelLarge
+        )
+
+        Text(
+            text = formatDuration(estimatedSeconds),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        Slider(
+            value = estimatedSeconds.toFloat(),
+            onValueChange = { onEstimatedSecondsChanged(it.toInt()) },
+            valueRange = 60f..3600f,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Micro version section
+        Text(
+            text = "Micro version",
+            style = MaterialTheme.typography.labelLarge
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        OutlinedTextField(
+            value = microVersion,
+            onValueChange = onMicroVersionChanged,
+            label = { Text("Micro version") },
+            placeholder = { Text("The smallest possible version of this habit") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            supportingText = { Text("The smallest possible version of this habit") }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Frequency section
+        Text(
+            text = "Frequency",
+            style = MaterialTheme.typography.labelLarge
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            frequencyOptions.forEachIndexed { index, freq ->
+                SegmentedButton(
+                    selected = frequency == freq,
+                    onClick = { onFrequencySelected(freq) },
+                    shape = SegmentedButtonDefaults.itemShape(
+                        index = index,
+                        count = frequencyOptions.size
+                    ),
+                    label = { Text(freq.displayName) }
+                )
+            }
+        }
+
+        if (frequency is HabitFrequency.Custom) {
+            Spacer(modifier = Modifier.height(8.dp))
+
+            FlowRow(modifier = Modifier.fillMaxWidth()) {
+                daysOfWeek.forEach { day ->
+                    FilterChip(
+                        selected = day in activeDays,
+                        onClick = {
+                            val newDays = if (day in activeDays) {
+                                activeDays - day
+                            } else {
+                                activeDays + day
+                            }
+                            onActiveDaysChanged(newDays)
+                        },
+                        label = { Text(dayLabel(day)) },
+                        modifier = Modifier.padding(end = 4.dp, bottom = 4.dp)
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Icon section
+        Text(
+            text = "Icon",
+            style = MaterialTheme.typography.labelLarge
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        LazyRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            items(habitIcons) { habitIcon ->
+                val isSelected = icon == habitIcon.name
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (isSelected) {
+                                MaterialTheme.colorScheme.primaryContainer
+                            } else {
+                                MaterialTheme.colorScheme.surfaceVariant
+                            }
+                        )
+                        .border(
+                            width = if (isSelected) 2.dp else 0.dp,
+                            color = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent,
+                            shape = CircleShape
+                        )
+                        .clickable {
+                            onIconSelected(if (isSelected) null else habitIcon.name)
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = habitIcon.vector,
+                        contentDescription = habitIcon.name,
+                        tint = if (isSelected) {
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Color section
+        Text(
+            text = "Color",
+            style = MaterialTheme.typography.labelLarge
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            habitColors.forEach { (hex, colorValue) ->
+                val isSelected = color == hex
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .background(colorValue)
+                        .border(
+                            width = if (isSelected) 3.dp else 0.dp,
+                            color = if (isSelected) MaterialTheme.colorScheme.onSurface else Color.Transparent,
+                            shape = CircleShape
+                        )
+                        .clickable { onColorSelected(if (isSelected) null else hex) }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = onCreateHabit,
+            enabled = !isCreating,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Create Habit")
+        }
+
+        TextButton(
+            onClick = onCreateHabit,
+            enabled = !isCreating,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Skip, use defaults")
+        }
+    }
+}

--- a/feature/habit/src/test/kotlin/com/getaltair/kairos/feature/habit/CreateHabitViewModelTest.kt
+++ b/feature/habit/src/test/kotlin/com/getaltair/kairos/feature/habit/CreateHabitViewModelTest.kt
@@ -1,0 +1,745 @@
+package com.getaltair.kairos.feature.habit
+
+import com.getaltair.kairos.domain.common.Result
+import com.getaltair.kairos.domain.entity.Habit
+import com.getaltair.kairos.domain.enums.AnchorType
+import com.getaltair.kairos.domain.enums.HabitCategory
+import com.getaltair.kairos.domain.enums.HabitFrequency
+import com.getaltair.kairos.domain.enums.HabitPhase
+import com.getaltair.kairos.domain.enums.HabitStatus
+import com.getaltair.kairos.domain.usecase.CreateHabitUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import java.time.DayOfWeek
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CreateHabitViewModelTest {
+
+    private val createHabitUseCase: CreateHabitUseCase = mockk()
+    private lateinit var viewModel: CreateHabitViewModel
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = CreateHabitViewModel(createHabitUseCase)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // -------------------------------------------------------------------------
+    // 1. Initial state
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `initial state - currentStep is NAME`() {
+        assertEquals(WizardStep.NAME, viewModel.uiState.value.currentStep)
+    }
+
+    @Test
+    fun `initial state - name is empty`() {
+        assertEquals("", viewModel.uiState.value.name)
+    }
+
+    @Test
+    fun `initial state - anchorType is AfterBehavior`() {
+        assertEquals(AnchorType.AfterBehavior, viewModel.uiState.value.anchorType)
+    }
+
+    @Test
+    fun `initial state - isCreating is false`() {
+        assertFalse(viewModel.uiState.value.isCreating)
+    }
+
+    @Test
+    fun `initial state - category is null`() {
+        assertNull(viewModel.uiState.value.category)
+    }
+
+    @Test
+    fun `initial state - frequency is Daily`() {
+        assertEquals(HabitFrequency.Daily, viewModel.uiState.value.frequency)
+    }
+
+    @Test
+    fun `initial state - estimatedSeconds is 300`() {
+        assertEquals(300, viewModel.uiState.value.estimatedSeconds)
+    }
+
+    @Test
+    fun `initial state - isCreated is false`() {
+        assertFalse(viewModel.uiState.value.isCreated)
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. onNameChanged
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onNameChanged updates name in state`() {
+        viewModel.onNameChanged("My New Habit")
+
+        assertEquals("My New Habit", viewModel.uiState.value.name)
+    }
+
+    @Test
+    fun `onNameChanged clears nameError`() {
+        // First trigger a nameError by attempting to advance with blank name
+        viewModel.goToNextStep()
+        assertNotNull(viewModel.uiState.value.nameError)
+
+        // Now changing the name should clear the error
+        viewModel.onNameChanged("Valid Name")
+        assertNull(viewModel.uiState.value.nameError)
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. goToNextStep from NAME - validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `goToNextStep from NAME with blank name sets nameError and stays on NAME`() {
+        viewModel.onNameChanged("")
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.NAME, viewModel.uiState.value.currentStep)
+        assertNotNull(viewModel.uiState.value.nameError)
+        assertEquals("Name is required", viewModel.uiState.value.nameError)
+    }
+
+    @Test
+    fun `goToNextStep from NAME with whitespace only name sets nameError and stays on NAME`() {
+        viewModel.onNameChanged("   ")
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.NAME, viewModel.uiState.value.currentStep)
+        assertNotNull(viewModel.uiState.value.nameError)
+    }
+
+    @Test
+    fun `goToNextStep from NAME with name over 100 chars sets nameError and stays on NAME`() {
+        val longName = "a".repeat(101)
+        viewModel.onNameChanged(longName)
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.NAME, viewModel.uiState.value.currentStep)
+        assertEquals("Name must be 100 characters or fewer", viewModel.uiState.value.nameError)
+    }
+
+    @Test
+    fun `goToNextStep from NAME with valid name advances to ANCHOR`() {
+        viewModel.onNameChanged("Morning Meditation")
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.ANCHOR, viewModel.uiState.value.currentStep)
+        assertNull(viewModel.uiState.value.nameError)
+    }
+
+    @Test
+    fun `goToNextStep from NAME with exactly 100 chars advances to ANCHOR`() {
+        val maxName = "a".repeat(100)
+        viewModel.onNameChanged(maxName)
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.ANCHOR, viewModel.uiState.value.currentStep)
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. goToNextStep from ANCHOR - validation
+    // -------------------------------------------------------------------------
+
+    private fun advanceToAnchorStep() {
+        viewModel.onNameChanged("Valid Habit")
+        viewModel.goToNextStep()
+    }
+
+    @Test
+    fun `goToNextStep from ANCHOR with default anchorType and blank behavior sets anchorError`() {
+        advanceToAnchorStep()
+        // anchorType defaults to AfterBehavior and anchorBehavior is blank
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.ANCHOR, viewModel.uiState.value.currentStep)
+        assertEquals("Please describe the anchor behavior", viewModel.uiState.value.anchorError)
+    }
+
+    @Test
+    fun `goToNextStep from ANCHOR with AfterBehavior but blank anchorBehavior sets anchorError`() {
+        advanceToAnchorStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AfterBehavior)
+        // anchorBehavior is cleared to "" by onAnchorTypeSelected
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.ANCHOR, viewModel.uiState.value.currentStep)
+        assertEquals("Please describe the anchor behavior", viewModel.uiState.value.anchorError)
+    }
+
+    @Test
+    fun `goToNextStep from ANCHOR with AfterBehavior and non-blank anchorBehavior advances to CATEGORY`() {
+        advanceToAnchorStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AfterBehavior)
+        viewModel.onAnchorBehaviorChanged("After brushing teeth")
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.CATEGORY, viewModel.uiState.value.currentStep)
+        assertNull(viewModel.uiState.value.anchorError)
+    }
+
+    @Test
+    fun `goToNextStep from ANCHOR with AtTime but null anchorTime sets anchorError`() {
+        advanceToAnchorStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AtTime)
+        // anchorTime is null after selecting AtTime (cleared by onAnchorTypeSelected)
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.ANCHOR, viewModel.uiState.value.currentStep)
+        assertEquals("Please set a time", viewModel.uiState.value.anchorError)
+    }
+
+    @Test
+    fun `goToNextStep from ANCHOR with AtTime and non-blank anchorTime advances to CATEGORY`() {
+        advanceToAnchorStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AtTime)
+        viewModel.onAnchorTimeChanged("07:30")
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.CATEGORY, viewModel.uiState.value.currentStep)
+        assertNull(viewModel.uiState.value.anchorError)
+    }
+
+    @Test
+    fun `goToNextStep from ANCHOR with BeforeBehavior and non-blank anchorBehavior advances to CATEGORY`() {
+        advanceToAnchorStep()
+        viewModel.onAnchorTypeSelected(AnchorType.BeforeBehavior)
+        viewModel.onAnchorBehaviorChanged("Before lunch")
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.CATEGORY, viewModel.uiState.value.currentStep)
+    }
+
+    // -------------------------------------------------------------------------
+    // 5. goToNextStep from CATEGORY - validation
+    // -------------------------------------------------------------------------
+
+    private fun advanceToCategoryStep() {
+        advanceToAnchorStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AfterBehavior)
+        viewModel.onAnchorBehaviorChanged("After waking up")
+        viewModel.goToNextStep()
+    }
+
+    @Test
+    fun `goToNextStep from CATEGORY with no category sets categoryError and stays on CATEGORY`() {
+        advanceToCategoryStep()
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.CATEGORY, viewModel.uiState.value.currentStep)
+        assertEquals("Please select a category", viewModel.uiState.value.categoryError)
+    }
+
+    @Test
+    fun `goToNextStep from CATEGORY with category selected advances to OPTIONS`() {
+        advanceToCategoryStep()
+        viewModel.onCategorySelected(HabitCategory.Morning)
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.OPTIONS, viewModel.uiState.value.currentStep)
+        assertNull(viewModel.uiState.value.categoryError)
+    }
+
+    // -------------------------------------------------------------------------
+    // 6. goToPreviousStep
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `goToPreviousStep from NAME stays on NAME`() {
+        viewModel.goToPreviousStep()
+
+        assertEquals(WizardStep.NAME, viewModel.uiState.value.currentStep)
+    }
+
+    @Test
+    fun `goToPreviousStep from NAME preserves existing name`() {
+        viewModel.onNameChanged("My Habit")
+        viewModel.goToPreviousStep()
+
+        assertEquals(WizardStep.NAME, viewModel.uiState.value.currentStep)
+        assertEquals("My Habit", viewModel.uiState.value.name)
+    }
+
+    @Test
+    fun `goToPreviousStep from ANCHOR goes back to NAME`() {
+        viewModel.onNameChanged("Valid Habit")
+        viewModel.goToNextStep()
+        assertEquals(WizardStep.ANCHOR, viewModel.uiState.value.currentStep)
+
+        viewModel.goToPreviousStep()
+
+        assertEquals(WizardStep.NAME, viewModel.uiState.value.currentStep)
+    }
+
+    @Test
+    fun `goToPreviousStep from ANCHOR preserves name value`() {
+        viewModel.onNameChanged("Valid Habit")
+        viewModel.goToNextStep()
+        viewModel.goToPreviousStep()
+
+        assertEquals("Valid Habit", viewModel.uiState.value.name)
+    }
+
+    @Test
+    fun `goToPreviousStep from CATEGORY goes back to ANCHOR`() {
+        advanceToCategoryStep()
+
+        viewModel.goToPreviousStep()
+
+        assertEquals(WizardStep.ANCHOR, viewModel.uiState.value.currentStep)
+    }
+
+    @Test
+    fun `goToPreviousStep from OPTIONS goes back to CATEGORY`() {
+        advanceToCategoryStep()
+        viewModel.onCategorySelected(HabitCategory.Evening)
+        viewModel.goToNextStep()
+        assertEquals(WizardStep.OPTIONS, viewModel.uiState.value.currentStep)
+
+        viewModel.goToPreviousStep()
+
+        assertEquals(WizardStep.CATEGORY, viewModel.uiState.value.currentStep)
+    }
+
+    // -------------------------------------------------------------------------
+    // 7. createHabit success
+    // -------------------------------------------------------------------------
+
+    private fun setupForCreate(
+        name: String = "Morning Meditation",
+        anchorBehavior: String = "After brushing teeth",
+        category: HabitCategory = HabitCategory.Morning
+    ) {
+        viewModel.onNameChanged(name)
+        viewModel.goToNextStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AfterBehavior)
+        viewModel.onAnchorBehaviorChanged(anchorBehavior)
+        viewModel.goToNextStep()
+        viewModel.onCategorySelected(category)
+        viewModel.goToNextStep()
+    }
+
+    @Test
+    fun `createHabit success sets isCreated to true`() = runTest {
+        setupForCreate()
+        coEvery { createHabitUseCase(any()) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isCreated)
+    }
+
+    @Test
+    fun `createHabit success sets isCreating to false after completion`() = runTest {
+        setupForCreate()
+        coEvery { createHabitUseCase(any()) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isCreating)
+    }
+
+    @Test
+    fun `createHabit passes habit with correct phase to use case`() = runTest {
+        setupForCreate()
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertEquals(HabitPhase.ONBOARD, habitSlot.captured.phase)
+    }
+
+    @Test
+    fun `createHabit passes habit with correct status to use case`() = runTest {
+        setupForCreate()
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertEquals(HabitStatus.Active, habitSlot.captured.status)
+    }
+
+    @Test
+    fun `createHabit passes habit with allowPartialCompletion true`() = runTest {
+        setupForCreate()
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertTrue(habitSlot.captured.allowPartialCompletion)
+    }
+
+    @Test
+    fun `createHabit passes habit with lapseThresholdDays 3`() = runTest {
+        setupForCreate()
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertEquals(3, habitSlot.captured.lapseThresholdDays)
+    }
+
+    @Test
+    fun `createHabit passes habit with relapseThresholdDays 7`() = runTest {
+        setupForCreate()
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertEquals(7, habitSlot.captured.relapseThresholdDays)
+    }
+
+    @Test
+    fun `createHabit passes habit with correct name`() = runTest {
+        setupForCreate(name = "Evening Walk")
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertEquals("Evening Walk", habitSlot.captured.name)
+    }
+
+    @Test
+    fun `createHabit passes habit with correct category`() = runTest {
+        setupForCreate(category = HabitCategory.Evening)
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertEquals(HabitCategory.Evening, habitSlot.captured.category)
+    }
+
+    @Test
+    fun `createHabit passes habit with correct anchorBehavior`() = runTest {
+        setupForCreate(anchorBehavior = "After lunch")
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertEquals("After lunch", habitSlot.captured.anchorBehavior)
+    }
+
+    @Test
+    fun `createHabit passes habit with default Daily frequency`() = runTest {
+        setupForCreate()
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertEquals(HabitFrequency.Daily, habitSlot.captured.frequency)
+    }
+
+    @Test
+    fun `createHabit calls use case exactly once`() = runTest {
+        setupForCreate()
+        coEvery { createHabitUseCase(any()) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { createHabitUseCase(any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // 8. createHabit failure
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createHabit failure sets creationError to error message`() = runTest {
+        setupForCreate()
+        coEvery { createHabitUseCase(any()) } returns Result.Error("Database write failed")
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertEquals("Database write failed", viewModel.uiState.value.creationError)
+    }
+
+    @Test
+    fun `createHabit failure leaves isCreated false`() = runTest {
+        setupForCreate()
+        coEvery { createHabitUseCase(any()) } returns Result.Error("Save failed")
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isCreated)
+    }
+
+    @Test
+    fun `createHabit failure resets isCreating to false`() = runTest {
+        setupForCreate()
+        coEvery { createHabitUseCase(any()) } returns Result.Error("Save failed")
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isCreating)
+    }
+
+    // -------------------------------------------------------------------------
+    // 9. Custom frequency
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onFrequencySelected Custom sets frequency to Custom`() {
+        viewModel.onFrequencySelected(HabitFrequency.Custom)
+
+        assertEquals(HabitFrequency.Custom, viewModel.uiState.value.frequency)
+    }
+
+    @Test
+    fun `onActiveDaysChanged sets activeDays`() {
+        viewModel.onFrequencySelected(HabitFrequency.Custom)
+        viewModel.onActiveDaysChanged(setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY))
+
+        assertEquals(setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY), viewModel.uiState.value.activeDays)
+    }
+
+    @Test
+    fun `createHabit with Custom frequency passes activeDays to use case`() = runTest {
+        setupForCreate()
+        viewModel.onFrequencySelected(HabitFrequency.Custom)
+        viewModel.onActiveDaysChanged(setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY))
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertEquals(HabitFrequency.Custom, habitSlot.captured.frequency)
+        assertEquals(
+            setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY),
+            habitSlot.captured.activeDays
+        )
+    }
+
+    @Test
+    fun `createHabit with Daily frequency passes null activeDays to use case`() = runTest {
+        setupForCreate()
+        // Frequency is Daily by default
+        val habitSlot = slot<Habit>()
+        coEvery { createHabitUseCase(capture(habitSlot)) } returns Result.Success(mockk(relaxed = true))
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        assertNull(habitSlot.captured.activeDays)
+    }
+
+    // -------------------------------------------------------------------------
+    // 10. Anchor type switching clears anchorBehavior and anchorTime
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `switching anchorType clears anchorBehavior`() {
+        viewModel.onNameChanged("Valid Habit")
+        viewModel.goToNextStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AfterBehavior)
+        viewModel.onAnchorBehaviorChanged("After coffee")
+
+        // Switch to a different anchor type
+        viewModel.onAnchorTypeSelected(AnchorType.BeforeBehavior)
+
+        assertEquals("", viewModel.uiState.value.anchorBehavior)
+    }
+
+    @Test
+    fun `switching anchorType clears anchorTime`() {
+        viewModel.onNameChanged("Valid Habit")
+        viewModel.goToNextStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AtTime)
+        viewModel.onAnchorTimeChanged("08:00")
+        assertNotNull(viewModel.uiState.value.anchorTime)
+
+        // Switch to a different anchor type
+        viewModel.onAnchorTypeSelected(AnchorType.AfterBehavior)
+
+        assertNull(viewModel.uiState.value.anchorTime)
+    }
+
+    @Test
+    fun `switching anchorType clears anchorError`() {
+        viewModel.onNameChanged("Valid Habit")
+        viewModel.goToNextStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AfterBehavior)
+        // Leave anchorBehavior blank and advance to trigger error
+        viewModel.goToNextStep()
+        assertNotNull(viewModel.uiState.value.anchorError)
+
+        // Switching type clears the error
+        viewModel.onAnchorTypeSelected(AnchorType.AtTime)
+
+        assertNull(viewModel.uiState.value.anchorError)
+    }
+
+    @Test
+    fun `switching anchorType updates anchorType in state`() {
+        viewModel.onNameChanged("Valid Habit")
+        viewModel.goToNextStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AfterBehavior)
+        assertEquals(AnchorType.AfterBehavior, viewModel.uiState.value.anchorType)
+
+        viewModel.onAnchorTypeSelected(AnchorType.AtLocation)
+
+        assertEquals(AnchorType.AtLocation, viewModel.uiState.value.anchorType)
+    }
+
+    // -------------------------------------------------------------------------
+    // 11. createHabit with null category sets creationError
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createHabit with null category sets creationError`() = runTest {
+        // Set up state with all fields except category
+        viewModel.onNameChanged("Morning Meditation")
+        viewModel.goToNextStep()
+        viewModel.onAnchorTypeSelected(AnchorType.AfterBehavior)
+        viewModel.onAnchorBehaviorChanged("After brushing teeth")
+        viewModel.goToNextStep()
+        // Do NOT select a category -- it remains null
+        viewModel.goToNextStep() // advances to OPTIONS only if category is set; stays on CATEGORY
+        // Force to OPTIONS by selecting category then clearing -- instead, just call createHabit directly
+        // The ViewModel's createHabit checks category == null independently of wizard step
+        // Reset ViewModel and call createHabit without setting category
+        val freshViewModel = CreateHabitViewModel(createHabitUseCase)
+        freshViewModel.onNameChanged("Morning Meditation")
+
+        freshViewModel.createHabit()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { createHabitUseCase(any()) }
+        assertNotNull(freshViewModel.uiState.value.creationError)
+    }
+
+    // -------------------------------------------------------------------------
+    // 12. onAnchorTimeChanged sets both anchorTime and anchorBehavior
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onAnchorTimeChanged sets both anchorTime and anchorBehavior`() {
+        viewModel.onAnchorTimeChanged("07:30")
+
+        assertEquals("07:30", viewModel.uiState.value.anchorTime)
+        assertEquals("07:30", viewModel.uiState.value.anchorBehavior)
+    }
+
+    // -------------------------------------------------------------------------
+    // 13. goToNextStep from OPTIONS stays on OPTIONS
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `goToNextStep from OPTIONS stays on OPTIONS`() {
+        advanceToCategoryStep()
+        viewModel.onCategorySelected(HabitCategory.Morning)
+        viewModel.goToNextStep()
+        assertEquals(WizardStep.OPTIONS, viewModel.uiState.value.currentStep)
+
+        viewModel.goToNextStep()
+
+        assertEquals(WizardStep.OPTIONS, viewModel.uiState.value.currentStep)
+    }
+
+    // -------------------------------------------------------------------------
+    // 14. clearCreationError clears creationError
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `clearCreationError clears creationError`() = runTest {
+        // Trigger a creationError by calling createHabit with null category
+        val freshViewModel = CreateHabitViewModel(createHabitUseCase)
+        freshViewModel.onNameChanged("Some Habit")
+        freshViewModel.createHabit()
+        advanceUntilIdle()
+        assertNotNull(freshViewModel.uiState.value.creationError)
+
+        freshViewModel.clearCreationError()
+
+        assertNull(freshViewModel.uiState.value.creationError)
+    }
+
+    // -------------------------------------------------------------------------
+    // 15. Double-submission guard
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createHabit called twice rapidly invokes use case only once`() = runTest {
+        setupForCreate()
+        val deferred = kotlinx.coroutines.CompletableDeferred<Result<Habit>>()
+        coEvery { createHabitUseCase(any()) } coAnswers { deferred.await() }
+
+        viewModel.createHabit()
+        // isCreating is now true because the coroutine is suspended
+        viewModel.createHabit()
+        // Complete the deferred so the first call finishes
+        deferred.complete(Result.Success(mockk(relaxed = true)))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { createHabitUseCase(any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // 16. Custom frequency with empty activeDays sets creationError
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createHabit with Custom frequency and empty activeDays sets creationError`() = runTest {
+        setupForCreate()
+        viewModel.onFrequencySelected(HabitFrequency.Custom)
+        // Do NOT select any active days
+
+        viewModel.createHabit()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { createHabitUseCase(any()) }
+        assertNotNull(viewModel.uiState.value.creationError)
+    }
+}

--- a/feature/today/src/main/kotlin/com/getaltair/kairos/feature/today/TodayScreen.kt
+++ b/feature/today/src/main/kotlin/com/getaltair/kairos/feature/today/TodayScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.getaltair.kairos.domain.enums.CompletionType
-import com.getaltair.kairos.domain.enums.HabitCategory
 import com.getaltair.kairos.domain.model.HabitWithStatus
 import com.getaltair.kairos.feature.today.components.CompletionBottomSheet
 import com.getaltair.kairos.feature.today.components.EmptyState
@@ -51,7 +50,7 @@ import org.koin.androidx.compose.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TodayScreen(viewModel: TodayViewModel = koinViewModel()) {
+fun TodayScreen(onAddHabit: () -> Unit = {}, viewModel: TodayViewModel = koinViewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val haptic = LocalHapticFeedback.current
     var selectedHabit by remember { mutableStateOf<HabitWithStatus?>(null) }
@@ -102,7 +101,7 @@ fun TodayScreen(viewModel: TodayViewModel = koinViewModel()) {
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
-            FloatingActionButton(onClick = { /* TODO: Step 6 */ }) {
+            FloatingActionButton(onClick = onAddHabit) {
                 Icon(Icons.Filled.Add, contentDescription = "Add habit")
             }
         }
@@ -184,7 +183,7 @@ fun TodayScreen(viewModel: TodayViewModel = koinViewModel()) {
                     uiState.habitsByCategory.forEach { (category, habits) ->
                         item {
                             Text(
-                                text = "${categoryEmoji(category)} ${categoryName(category)}",
+                                text = "${category.emoji} ${category.displayName}",
                                 style = MaterialTheme.typography.titleSmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
@@ -226,20 +225,4 @@ fun TodayScreen(viewModel: TodayViewModel = koinViewModel()) {
             onDismiss = { selectedHabit = null }
         )
     }
-}
-
-private fun categoryEmoji(category: HabitCategory): String = when (category) {
-    is HabitCategory.Morning -> category.emoji
-    is HabitCategory.Afternoon -> category.emoji
-    is HabitCategory.Evening -> category.emoji
-    is HabitCategory.Anytime -> category.emoji
-    is HabitCategory.Departure -> category.emoji
-}
-
-private fun categoryName(category: HabitCategory): String = when (category) {
-    is HabitCategory.Morning -> category.displayName
-    is HabitCategory.Afternoon -> category.displayName
-    is HabitCategory.Evening -> category.displayName
-    is HabitCategory.Anytime -> category.displayName
-    is HabitCategory.Departure -> category.displayName
 }


### PR DESCRIPTION
## Summary

- Implements a 4-step wizard (Name → Category → Anchor → Options) for creating habits
- Full ViewModel with UI state management, DI wiring via Koin, and navigation integration
- All PR review findings addressed: 2 critical bugs, 5 high-severity issues, 8 code quality cleanups

## Changes

### Feature
- `CreateHabitScreen.kt` — wizard host with progress indicator and step navigation
- `CreateHabitViewModel.kt` — state machine driving wizard progression and habit creation
- `CreateHabitUiState.kt` — sealed/data class UI state
- Step composables: `NameStep`, `CategoryStep`, `AnchorStep`, `OptionsStep`
- `HabitModule.kt` — Koin DI wiring for ViewModel
- Navigation wired in `KairosNavGraph.kt`; FAB added to Today screen

### Bug Fixes (from PR review)
- Replace `LazyVerticalGrid` inside `verticalScroll` with `Column+Row` (crash fix)
- Replace silent `?: return` with `creationError` + `Timber.e()` logging
- Add double-submission guard (`isCreating` check) in `createHabit()`
- Wrap coroutine body in `try-catch`, always reset `isCreating` in finally path
- Validate Custom frequency requires at least one active day selected
- Make `anchorType` non-nullable with default `AnchorType.AfterBehavior`

### Code Quality
- `Color.Red` → `MaterialTheme.colorScheme.error` in all 3 step files
- Remove dead `onSkip` parameter from `OptionsStep`
- Remove no-op `.map` from `habitColors`
- Replace hardcoded step count with `WizardStep.entries.size`
- Remove redundant `categoryEmoji()`/`categoryName()` from `TodayScreen`

## Test plan

- [ ] `./gradlew :feature:habit:test` — 58 unit tests pass
- [ ] `./gradlew :feature:habit:build :feature:today:build :app:build` — BUILD SUCCESSFUL
- [ ] Navigate to Today screen → FAB launches wizard
- [ ] Complete wizard end-to-end → habit created and shown on Today screen
- [ ] Category step renders without crash (no nested scroll)
- [ ] Submitting with no category shows error message
- [ ] Custom frequency with no days selected shows error message
- [ ] Tapping Create twice rapidly only submits once