### PR TITLE
feat: account deletion (#34)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,9 @@ dependencies {
     implementation(project(":sync"))
     implementation(project(":notification"))
 
+    // Room (needed for KairosDatabase.clearAllTables in DataCleanupImpl)
+    implementation(libs.androidx.room.runtime)
+
     // Android Core
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/kotlin/com/getaltair/kairos/cleanup/DataCleanupImpl.kt
+++ b/app/src/main/kotlin/com/getaltair/kairos/cleanup/DataCleanupImpl.kt
@@ -1,8 +1,10 @@
-package com.getaltair.kairos.di
+package com.getaltair.kairos.cleanup
 
 import com.getaltair.kairos.data.database.KairosDatabase
 import com.getaltair.kairos.domain.sync.DataCleanup
 import com.getaltair.kairos.sync.SyncManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Bridges the domain-layer [DataCleanup] interface with concrete infrastructure.
@@ -11,17 +13,15 @@ import com.getaltair.kairos.sync.SyncManager
  * to [KairosDatabase]. Lives in the app module because it needs access to
  * both the sync and data modules, which the domain layer cannot depend on.
  */
-class DataCleanupImpl(private val syncManager: SyncManager, private val database: KairosDatabase) : DataCleanup {
-
-    override fun stopSyncListeners() {
-        syncManager.stopListening()
-    }
+class DataCleanupImpl(private val syncManager: SyncManager, private val database: KairosDatabase,) : DataCleanup {
 
     override suspend fun deleteCloudData(userId: String) {
         syncManager.deleteAllUserData(userId)
     }
 
-    override fun clearLocalData() {
-        database.clearAllTables()
+    override suspend fun clearLocalData() {
+        withContext(Dispatchers.IO) {
+            database.clearAllTables()
+        }
     }
 }

--- a/app/src/main/kotlin/com/getaltair/kairos/di/DataCleanupImpl.kt
+++ b/app/src/main/kotlin/com/getaltair/kairos/di/DataCleanupImpl.kt
@@ -1,0 +1,27 @@
+package com.getaltair.kairos.di
+
+import com.getaltair.kairos.data.database.KairosDatabase
+import com.getaltair.kairos.domain.sync.DataCleanup
+import com.getaltair.kairos.sync.SyncManager
+
+/**
+ * Bridges the domain-layer [DataCleanup] interface with concrete infrastructure.
+ *
+ * Delegates sync operations to [SyncManager] and local storage operations
+ * to [KairosDatabase]. Lives in the app module because it needs access to
+ * both the sync and data modules, which the domain layer cannot depend on.
+ */
+class DataCleanupImpl(private val syncManager: SyncManager, private val database: KairosDatabase) : DataCleanup {
+
+    override fun stopSyncListeners() {
+        syncManager.stopListening()
+    }
+
+    override suspend fun deleteCloudData(userId: String) {
+        syncManager.deleteAllUserData(userId)
+    }
+
+    override fun clearLocalData() {
+        database.clearAllTables()
+    }
+}

--- a/app/src/main/kotlin/com/getaltair/kairos/di/FirebaseModule.kt
+++ b/app/src/main/kotlin/com/getaltair/kairos/di/FirebaseModule.kt
@@ -1,5 +1,8 @@
 package com.getaltair.kairos.di
 
+import com.getaltair.kairos.data.database.KairosDatabase
+import com.getaltair.kairos.domain.sync.DataCleanup
+import com.getaltair.kairos.sync.SyncManager
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import org.koin.dsl.module
@@ -9,8 +12,14 @@ import org.koin.dsl.module
  * can inject. These are resolved lazily so Firebase must already be
  * initialized (via google-services.json or [com.getaltair.kairos.data.firebase.FirebaseInitializer]) before
  * any consumer touches them.
+ *
+ * Also provides the [DataCleanup] binding that bridges the domain-layer
+ * interface with concrete sync and database infrastructure.
  */
 val firebaseModule = module {
     single<FirebaseAuth> { FirebaseAuth.getInstance() }
     single<FirebaseFirestore> { FirebaseFirestore.getInstance() }
+
+    // Account deletion infrastructure: bridges SyncManager + KairosDatabase
+    single<DataCleanup> { DataCleanupImpl(get<SyncManager>(), get<KairosDatabase>()) }
 }

--- a/app/src/main/kotlin/com/getaltair/kairos/di/FirebaseModule.kt
+++ b/app/src/main/kotlin/com/getaltair/kairos/di/FirebaseModule.kt
@@ -1,5 +1,6 @@
 package com.getaltair.kairos.di
 
+import com.getaltair.kairos.cleanup.DataCleanupImpl
 import com.getaltair.kairos.data.database.KairosDatabase
 import com.getaltair.kairos.domain.sync.DataCleanup
 import com.getaltair.kairos.sync.SyncManager

--- a/app/src/main/kotlin/com/getaltair/kairos/navigation/KairosNavGraph.kt
+++ b/app/src/main/kotlin/com/getaltair/kairos/navigation/KairosNavGraph.kt
@@ -179,6 +179,11 @@ fun KairosNavGraph(firebaseReady: Boolean) {
                 onNavigateToDashboardScan = {
                     navController.navigate("dashboardScan")
                 },
+                onAccountDeleted = {
+                    navController.navigate("today") {
+                        popUpTo(navController.graph.startDestinationId) { inclusive = true }
+                    }
+                },
                 onBack = { navController.popBackStack() }
             )
         }

--- a/app/src/test/kotlin/com/getaltair/kairos/KoinModuleCheckTest.kt
+++ b/app/src/test/kotlin/com/getaltair/kairos/KoinModuleCheckTest.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.getaltair.kairos.core.di.useCaseModule
 import com.getaltair.kairos.data.di.dataModule
 import com.getaltair.kairos.di.setupModule
+import com.getaltair.kairos.domain.sync.DataCleanup
 import com.getaltair.kairos.feature.auth.di.authModule
 import com.getaltair.kairos.feature.habit.di.habitModule
 import com.getaltair.kairos.feature.recovery.di.recoveryModule
@@ -54,6 +55,7 @@ class KoinModuleCheckTest {
         DataClient::class,
         MessageClient::class,
         CapabilityClient::class,
+        DataCleanup::class,
     )
 
     /**

--- a/core/src/main/kotlin/com/getaltair/kairos/core/di/UseCaseModule.kt
+++ b/core/src/main/kotlin/com/getaltair/kairos/core/di/UseCaseModule.kt
@@ -13,6 +13,7 @@ import com.getaltair.kairos.domain.usecase.CompleteRoutineUseCase
 import com.getaltair.kairos.domain.usecase.CreateHabitUseCase
 import com.getaltair.kairos.domain.usecase.CreateMissedCompletionsUseCase
 import com.getaltair.kairos.domain.usecase.CreateRoutineUseCase
+import com.getaltair.kairos.domain.usecase.DeleteAccountUseCase
 import com.getaltair.kairos.domain.usecase.DeleteHabitUseCase
 import com.getaltair.kairos.domain.usecase.DeleteRoutineUseCase
 import com.getaltair.kairos.domain.usecase.DetectLapsesUseCase
@@ -64,6 +65,7 @@ val useCaseModule = module {
     factory { SignOutUseCase(get()) }
     factory { ResetPasswordUseCase(get()) }
     factory { ObserveAuthStateUseCase(get()) }
+    factory { DeleteAccountUseCase(get(), get()) }
 
     // Recovery use cases
     factory { CreateMissedCompletionsUseCase(get(), get()) }

--- a/data/src/main/kotlin/com/getaltair/kairos/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/getaltair/kairos/data/repository/AuthRepositoryImpl.kt
@@ -86,12 +86,10 @@ class AuthRepositoryImpl(private val auth: FirebaseAuth) : AuthRepository {
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         Timber.e(e, "Failed to reauthenticate")
-        Result.Error("Failed to reauthenticate: ${e.message}", cause = e)
+        Result.Error("Something went wrong during re-authentication. Please try again.", cause = e)
     }
 
-    override suspend fun deleteAccount(password: String): Result<Unit> = try {
-        val reauthResult = reauthenticate(password)
-        if (reauthResult is Result.Error) return reauthResult
+    override suspend fun deleteAccount(): Result<Unit> = try {
         val user = auth.currentUser
             ?: return Result.Error("No signed-in user")
         user.delete().await()
@@ -99,7 +97,7 @@ class AuthRepositoryImpl(private val auth: FirebaseAuth) : AuthRepository {
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         Timber.e(e, "Failed to delete account")
-        Result.Error("Failed to delete account: ${e.message}", cause = e)
+        Result.Error("Unable to delete your account. Please try again or contact support.", cause = e)
     }
 
     override fun getCurrentUserId(): String? = auth.currentUser?.uid

--- a/data/src/main/kotlin/com/getaltair/kairos/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/getaltair/kairos/data/repository/AuthRepositoryImpl.kt
@@ -3,7 +3,9 @@ package com.getaltair.kairos.data.repository
 import com.getaltair.kairos.domain.common.Result
 import com.getaltair.kairos.domain.repository.AuthRepository
 import com.getaltair.kairos.domain.repository.AuthState
+import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -68,6 +70,36 @@ class AuthRepositoryImpl(private val auth: FirebaseAuth) : AuthRepository {
         if (e is CancellationException) throw e
         Timber.e(e, "Failed to send password reset email=%s", email)
         Result.Error("Failed to reset password: ${e.message}", cause = e)
+    }
+
+    override suspend fun reauthenticate(password: String): Result<Unit> = try {
+        val user = auth.currentUser
+            ?: return Result.Error("No signed-in user")
+        val email = user.email
+            ?: return Result.Error("User has no email address")
+        val credential = EmailAuthProvider.getCredential(email, password)
+        user.reauthenticate(credential).await()
+        Result.Success(Unit)
+    } catch (e: FirebaseAuthInvalidCredentialsException) {
+        Timber.e(e, "Reauthentication failed: invalid credentials")
+        Result.Error("Incorrect password. Please try again.", cause = e)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Timber.e(e, "Failed to reauthenticate")
+        Result.Error("Failed to reauthenticate: ${e.message}", cause = e)
+    }
+
+    override suspend fun deleteAccount(password: String): Result<Unit> = try {
+        val reauthResult = reauthenticate(password)
+        if (reauthResult is Result.Error) return reauthResult
+        val user = auth.currentUser
+            ?: return Result.Error("No signed-in user")
+        user.delete().await()
+        Result.Success(Unit)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Timber.e(e, "Failed to delete account")
+        Result.Error("Failed to delete account: ${e.message}", cause = e)
     }
 
     override fun getCurrentUserId(): String? = auth.currentUser?.uid

--- a/data/src/test/kotlin/com/getaltair/kairos/data/repository/AuthRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/getaltair/kairos/data/repository/AuthRepositoryImplTest.kt
@@ -2,8 +2,11 @@ package com.getaltair.kairos.data.repository
 
 import com.getaltair.kairos.domain.common.Result
 import com.google.android.gms.tasks.Task
+import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.AuthResult
+import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.FirebaseUser
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -174,5 +177,132 @@ class AuthRepositoryImplTest {
 
         assertTrue(result is Result.Error)
         assertTrue((result as Result.Error).message.contains("Failed to reset password"))
+    }
+
+    // ---- reauthenticate ----
+
+    @Test
+    fun `reauthenticate returns success when credentials are valid`() = runTest {
+        mockkStatic(EmailAuthProvider::class)
+        val user = mockk<FirebaseUser>()
+        val credential = mockk<AuthCredential>()
+        val taskMock = mockk<Task<Void>>()
+
+        every { firebaseAuth.currentUser } returns user
+        every { user.email } returns "test@test.com"
+        every { EmailAuthProvider.getCredential("test@test.com", "password") } returns credential
+        every { user.reauthenticate(credential) } returns taskMock
+        coEvery { taskMock.await() } returns mockk()
+
+        val result = repository.reauthenticate("password")
+
+        assertTrue(result is Result.Success)
+        unmockkStatic(EmailAuthProvider::class)
+    }
+
+    @Test
+    fun `reauthenticate returns error when no current user`() = runTest {
+        every { firebaseAuth.currentUser } returns null
+
+        val result = repository.reauthenticate("password")
+
+        assertTrue(result is Result.Error)
+        assertTrue((result as Result.Error).message.contains("No signed-in user"))
+    }
+
+    @Test
+    fun `reauthenticate returns error when user has null email`() = runTest {
+        val user = mockk<FirebaseUser>()
+        every { firebaseAuth.currentUser } returns user
+        every { user.email } returns null
+
+        val result = repository.reauthenticate("password")
+
+        assertTrue(result is Result.Error)
+        assertTrue((result as Result.Error).message.contains("no email"))
+    }
+
+    @Test
+    fun `reauthenticate returns error with user-friendly message on invalid credentials`() = runTest {
+        mockkStatic(EmailAuthProvider::class)
+        val user = mockk<FirebaseUser>()
+        val credential = mockk<AuthCredential>()
+        val taskMock = mockk<Task<Void>>()
+
+        every { firebaseAuth.currentUser } returns user
+        every { user.email } returns "test@test.com"
+        every { EmailAuthProvider.getCredential("test@test.com", "wrong") } returns credential
+        every { user.reauthenticate(credential) } returns taskMock
+        coEvery { taskMock.await() } throws FirebaseAuthInvalidCredentialsException(
+            "ERROR_WRONG_PASSWORD",
+            "The password is invalid",
+        )
+
+        val result = repository.reauthenticate("wrong")
+
+        assertTrue(result is Result.Error)
+        assertTrue((result as Result.Error).message.contains("Incorrect password"))
+        unmockkStatic(EmailAuthProvider::class)
+    }
+
+    @Test
+    fun `reauthenticate returns error on generic exception`() = runTest {
+        mockkStatic(EmailAuthProvider::class)
+        val user = mockk<FirebaseUser>()
+        val credential = mockk<AuthCredential>()
+        val taskMock = mockk<Task<Void>>()
+
+        every { firebaseAuth.currentUser } returns user
+        every { user.email } returns "test@test.com"
+        every { EmailAuthProvider.getCredential("test@test.com", "password") } returns credential
+        every { user.reauthenticate(credential) } returns taskMock
+        coEvery { taskMock.await() } throws RuntimeException("Network error")
+
+        val result = repository.reauthenticate("password")
+
+        assertTrue(result is Result.Error)
+        assertTrue((result as Result.Error).message.contains("Something went wrong"))
+        unmockkStatic(EmailAuthProvider::class)
+    }
+
+    // ---- deleteAccount ----
+
+    @Test
+    fun `deleteAccount returns success when user deletion succeeds`() = runTest {
+        val user = mockk<FirebaseUser>()
+        val taskMock = mockk<Task<Void>>()
+
+        every { firebaseAuth.currentUser } returns user
+        every { user.delete() } returns taskMock
+        coEvery { taskMock.await() } returns mockk()
+
+        val result = repository.deleteAccount()
+
+        assertTrue(result is Result.Success)
+    }
+
+    @Test
+    fun `deleteAccount returns error when no current user`() = runTest {
+        every { firebaseAuth.currentUser } returns null
+
+        val result = repository.deleteAccount()
+
+        assertTrue(result is Result.Error)
+        assertTrue((result as Result.Error).message.contains("No signed-in user"))
+    }
+
+    @Test
+    fun `deleteAccount returns error when user delete fails`() = runTest {
+        val user = mockk<FirebaseUser>()
+        val taskMock = mockk<Task<Void>>()
+
+        every { firebaseAuth.currentUser } returns user
+        every { user.delete() } returns taskMock
+        coEvery { taskMock.await() } throws RuntimeException("Requires recent login")
+
+        val result = repository.deleteAccount()
+
+        assertTrue(result is Result.Error)
+        assertTrue((result as Result.Error).message.contains("Unable to delete your account"))
     }
 }

--- a/domain/src/main/kotlin/com/getaltair/kairos/domain/repository/AuthRepository.kt
+++ b/domain/src/main/kotlin/com/getaltair/kairos/domain/repository/AuthRepository.kt
@@ -53,6 +53,18 @@ interface AuthRepository {
     suspend fun resetPassword(email: String): com.getaltair.kairos.domain.common.Result<Unit>
 
     /**
+     * Re-authenticates the current user with their password.
+     * Required by Firebase before sensitive operations like account deletion.
+     */
+    suspend fun reauthenticate(password: String): com.getaltair.kairos.domain.common.Result<Unit>
+
+    /**
+     * Permanently deletes the current user's account and all associated data.
+     * Re-authenticates with the given password before deletion.
+     */
+    suspend fun deleteAccount(password: String): com.getaltair.kairos.domain.common.Result<Unit>
+
+    /**
      * Returns the current user's ID, or null if not signed in.
      */
     fun getCurrentUserId(): String?

--- a/domain/src/main/kotlin/com/getaltair/kairos/domain/repository/AuthRepository.kt
+++ b/domain/src/main/kotlin/com/getaltair/kairos/domain/repository/AuthRepository.kt
@@ -54,15 +54,18 @@ interface AuthRepository {
 
     /**
      * Re-authenticates the current user with their password.
-     * Required by Firebase before sensitive operations like account deletion.
+     * Required before sensitive operations like account deletion.
      */
     suspend fun reauthenticate(password: String): com.getaltair.kairos.domain.common.Result<Unit>
 
     /**
-     * Permanently deletes the current user's account and all associated data.
-     * Re-authenticates with the given password before deletion.
+     * Permanently deletes the current user's authentication account.
+     *
+     * The caller is responsible for re-authenticating the user (via [reauthenticate])
+     * before invoking this method. This method only removes the auth account;
+     * data cleanup is the caller's responsibility.
      */
-    suspend fun deleteAccount(password: String): com.getaltair.kairos.domain.common.Result<Unit>
+    suspend fun deleteAccount(): com.getaltair.kairos.domain.common.Result<Unit>
 
     /**
      * Returns the current user's ID, or null if not signed in.

--- a/domain/src/main/kotlin/com/getaltair/kairos/domain/sync/DataCleanup.kt
+++ b/domain/src/main/kotlin/com/getaltair/kairos/domain/sync/DataCleanup.kt
@@ -7,15 +7,10 @@ package com.getaltair.kairos.domain.sync
  * domain layer can orchestrate account deletion without depending on concrete
  * infrastructure classes.
  *
- * Implemented in the app module where both [com.getaltair.kairos.sync.SyncManager]
- * and [com.getaltair.kairos.data.database.KairosDatabase] are accessible.
+ * Implemented in the app module where both the sync engine
+ * and the local database are accessible.
  */
 interface DataCleanup {
-
-    /**
-     * Stops all active sync listeners to prevent snapshot callbacks during deletion.
-     */
-    fun stopSyncListeners()
 
     /**
      * Deletes all Firestore cloud data for the given user, including all
@@ -29,5 +24,5 @@ interface DataCleanup {
     /**
      * Clears all local database tables, removing all persisted data.
      */
-    fun clearLocalData()
+    suspend fun clearLocalData()
 }

--- a/domain/src/main/kotlin/com/getaltair/kairos/domain/sync/DataCleanup.kt
+++ b/domain/src/main/kotlin/com/getaltair/kairos/domain/sync/DataCleanup.kt
@@ -1,0 +1,33 @@
+package com.getaltair.kairos.domain.sync
+
+/**
+ * Abstraction for data cleanup operations required during account deletion.
+ *
+ * Encapsulates both cloud (Firestore) and local (Room) data removal so the
+ * domain layer can orchestrate account deletion without depending on concrete
+ * infrastructure classes.
+ *
+ * Implemented in the app module where both [com.getaltair.kairos.sync.SyncManager]
+ * and [com.getaltair.kairos.data.database.KairosDatabase] are accessible.
+ */
+interface DataCleanup {
+
+    /**
+     * Stops all active sync listeners to prevent snapshot callbacks during deletion.
+     */
+    fun stopSyncListeners()
+
+    /**
+     * Deletes all Firestore cloud data for the given user, including all
+     * subcollections and the user document itself.
+     *
+     * @param userId The Firebase Auth user ID whose data should be removed.
+     * @throws Exception if any Firestore operation fails.
+     */
+    suspend fun deleteCloudData(userId: String)
+
+    /**
+     * Clears all local database tables, removing all persisted data.
+     */
+    fun clearLocalData()
+}

--- a/domain/src/main/kotlin/com/getaltair/kairos/domain/usecase/DeleteAccountUseCase.kt
+++ b/domain/src/main/kotlin/com/getaltair/kairos/domain/usecase/DeleteAccountUseCase.kt
@@ -1,0 +1,61 @@
+package com.getaltair.kairos.domain.usecase
+
+import com.getaltair.kairos.domain.common.Result
+import com.getaltair.kairos.domain.repository.AuthRepository
+import com.getaltair.kairos.domain.sync.DataCleanup
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Orchestrates the full account deletion flow.
+ *
+ * Performs the following steps in order:
+ * 1. Validates that a user is currently signed in.
+ * 2. Re-authenticates with the provided password (early validation before any data is touched).
+ * 3. Stops Firestore snapshot listeners to prevent callbacks during deletion.
+ * 4. Deletes all Firestore cloud data for the user.
+ * 5. Deletes the Firebase Auth account.
+ * 6. Clears all local Room database tables.
+ *
+ * The ordering ensures that cloud data is removed before the auth account, so a failure
+ * after Firestore deletion but before auth deletion leaves orphaned auth (recoverable)
+ * rather than orphaned cloud data (unrecoverable without the user's identity).
+ */
+class DeleteAccountUseCase(private val authRepository: AuthRepository, private val dataCleanup: DataCleanup) {
+
+    suspend operator fun invoke(password: String): Result<Unit> {
+        // Step 1: Verify user is signed in
+        val userId = authRepository.getCurrentUserId()
+        if (userId.isNullOrEmpty()) {
+            return Result.Error("No user is currently signed in")
+        }
+
+        // Step 2: Re-authenticate to validate password before any data changes
+        val reauthResult = authRepository.reauthenticate(password)
+        if (reauthResult is Result.Error) {
+            return reauthResult
+        }
+
+        return try {
+            // Step 3: Stop sync listeners to prevent snapshot callbacks during deletion
+            dataCleanup.stopSyncListeners()
+
+            // Step 4: Delete all Firestore data for this user
+            dataCleanup.deleteCloudData(userId)
+
+            // Step 5: Delete the Firebase Auth account
+            val deleteResult = authRepository.deleteAccount(password)
+            if (deleteResult is Result.Error) {
+                return deleteResult
+            }
+
+            // Step 6: Clear all local Room data
+            dataCleanup.clearLocalData()
+
+            Result.Success(Unit)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.Error("Account deletion failed: ${e.message}", cause = e)
+        }
+    }
+}

--- a/domain/src/main/kotlin/com/getaltair/kairos/domain/usecase/DeleteAccountUseCase.kt
+++ b/domain/src/main/kotlin/com/getaltair/kairos/domain/usecase/DeleteAccountUseCase.kt
@@ -11,14 +11,16 @@ import kotlin.coroutines.cancellation.CancellationException
  * Performs the following steps in order:
  * 1. Validates that a user is currently signed in.
  * 2. Re-authenticates with the provided password (early validation before any data is touched).
- * 3. Stops Firestore snapshot listeners to prevent callbacks during deletion.
- * 4. Deletes all Firestore cloud data for the user.
- * 5. Deletes the Firebase Auth account.
- * 6. Clears all local Room database tables.
+ * 3. Deletes all cloud data for the user (sync listeners are stopped internally).
+ * 4. Deletes the authentication account.
+ * 5. Clears all local database tables (best-effort; failure does not fail the operation).
  *
  * The ordering ensures that cloud data is removed before the auth account, so a failure
- * after Firestore deletion but before auth deletion leaves orphaned auth (recoverable)
+ * after cloud deletion but before auth deletion leaves orphaned auth (recoverable)
  * rather than orphaned cloud data (unrecoverable without the user's identity).
+ *
+ * If step 4 fails after step 3 has completed, a specific error message is returned
+ * informing the user that their data has already been removed.
  */
 class DeleteAccountUseCase(private val authRepository: AuthRepository, private val dataCleanup: DataCleanup) {
 
@@ -36,26 +38,33 @@ class DeleteAccountUseCase(private val authRepository: AuthRepository, private v
         }
 
         return try {
-            // Step 3: Stop sync listeners to prevent snapshot callbacks during deletion
-            dataCleanup.stopSyncListeners()
-
-            // Step 4: Delete all Firestore data for this user
+            // Step 3: Delete all Firestore data for this user
             dataCleanup.deleteCloudData(userId)
 
-            // Step 5: Delete the Firebase Auth account
-            val deleteResult = authRepository.deleteAccount(password)
+            // Step 4: Delete the auth account (Firestore data is already gone at this point)
+            val deleteResult = authRepository.deleteAccount()
             if (deleteResult is Result.Error) {
-                return deleteResult
+                return Result.Error(
+                    "Your data has been deleted, but we could not remove your account. " +
+                        "Please try signing out and deleting again, or contact support.",
+                    cause = deleteResult.cause,
+                )
             }
 
-            // Step 6: Clear all local Room data
-            dataCleanup.clearLocalData()
+            // Step 5: Clear local data (best-effort -- account is already gone)
+            try {
+                dataCleanup.clearLocalData()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Best-effort: account is already deleted, log swallowed at caller level
+            }
 
             Result.Success(Unit)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Result.Error("Account deletion failed: ${e.message}", cause = e)
+            Result.Error("Account deletion failed. Please try again or contact support.", cause = e)
         }
     }
 }

--- a/domain/src/test/kotlin/com/getaltair/kairos/domain/usecase/DeleteAccountUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/getaltair/kairos/domain/usecase/DeleteAccountUseCaseTest.kt
@@ -5,11 +5,11 @@ import com.getaltair.kairos.domain.repository.AuthRepository
 import com.getaltair.kairos.domain.sync.DataCleanup
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -37,22 +37,22 @@ class DeleteAccountUseCaseTest {
     fun `happy path deletes all data and returns success`() = runTest {
         every { authRepository.getCurrentUserId() } returns "user-123"
         coEvery { authRepository.reauthenticate("password") } returns Result.Success(Unit)
-        every { dataCleanup.stopSyncListeners() } just runs
         coEvery { dataCleanup.deleteCloudData("user-123") } just runs
-        coEvery { authRepository.deleteAccount("password") } returns Result.Success(Unit)
-        every { dataCleanup.clearLocalData() } just runs
+        coEvery { authRepository.deleteAccount() } returns Result.Success(Unit)
+        coEvery { dataCleanup.clearLocalData() } just runs
 
         val result = useCase("password")
 
         assertTrue(result is Result.Success)
 
         // Verify all steps were called in expected order
-        verify(exactly = 1) { authRepository.getCurrentUserId() }
-        coVerify(exactly = 1) { authRepository.reauthenticate("password") }
-        verify(exactly = 1) { dataCleanup.stopSyncListeners() }
-        coVerify(exactly = 1) { dataCleanup.deleteCloudData("user-123") }
-        coVerify(exactly = 1) { authRepository.deleteAccount("password") }
-        verify(exactly = 1) { dataCleanup.clearLocalData() }
+        coVerifyOrder {
+            authRepository.getCurrentUserId()
+            authRepository.reauthenticate("password")
+            dataCleanup.deleteCloudData("user-123")
+            authRepository.deleteAccount()
+            dataCleanup.clearLocalData()
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -71,10 +71,9 @@ class DeleteAccountUseCaseTest {
 
         // Nothing else should be called
         coVerify(exactly = 0) { authRepository.reauthenticate(any()) }
-        verify(exactly = 0) { dataCleanup.stopSyncListeners() }
         coVerify(exactly = 0) { dataCleanup.deleteCloudData(any()) }
-        coVerify(exactly = 0) { authRepository.deleteAccount(any()) }
-        verify(exactly = 0) { dataCleanup.clearLocalData() }
+        coVerify(exactly = 0) { authRepository.deleteAccount() }
+        coVerify(exactly = 0) { dataCleanup.clearLocalData() }
     }
 
     @Test
@@ -89,7 +88,7 @@ class DeleteAccountUseCaseTest {
 
         // Nothing else should be called
         coVerify(exactly = 0) { authRepository.reauthenticate(any()) }
-        verify(exactly = 0) { dataCleanup.stopSyncListeners() }
+        coVerify(exactly = 0) { dataCleanup.deleteCloudData(any()) }
     }
 
     // -------------------------------------------------------------------------
@@ -108,10 +107,9 @@ class DeleteAccountUseCaseTest {
         assertEquals("Incorrect password", (result as Result.Error).message)
 
         // Data operations must NOT be called
-        verify(exactly = 0) { dataCleanup.stopSyncListeners() }
         coVerify(exactly = 0) { dataCleanup.deleteCloudData(any()) }
-        coVerify(exactly = 0) { authRepository.deleteAccount(any()) }
-        verify(exactly = 0) { dataCleanup.clearLocalData() }
+        coVerify(exactly = 0) { authRepository.deleteAccount() }
+        coVerify(exactly = 0) { dataCleanup.clearLocalData() }
     }
 
     // -------------------------------------------------------------------------
@@ -122,7 +120,6 @@ class DeleteAccountUseCaseTest {
     fun `cloud data deletion failure returns error`() = runTest {
         every { authRepository.getCurrentUserId() } returns "user-123"
         coEvery { authRepository.reauthenticate("password") } returns Result.Success(Unit)
-        every { dataCleanup.stopSyncListeners() } just runs
         coEvery { dataCleanup.deleteCloudData("user-123") } throws
             RuntimeException("Firestore timeout")
 
@@ -131,11 +128,10 @@ class DeleteAccountUseCaseTest {
         assertTrue(result is Result.Error)
         val error = result as Result.Error
         assertTrue(error.message.contains("Account deletion failed"))
-        assertTrue(error.message.contains("Firestore timeout"))
 
         // Auth deletion and local cleanup should NOT proceed
-        coVerify(exactly = 0) { authRepository.deleteAccount(any()) }
-        verify(exactly = 0) { dataCleanup.clearLocalData() }
+        coVerify(exactly = 0) { authRepository.deleteAccount() }
+        coVerify(exactly = 0) { dataCleanup.clearLocalData() }
     }
 
     // -------------------------------------------------------------------------
@@ -146,18 +142,19 @@ class DeleteAccountUseCaseTest {
     fun `auth deletion failure returns error`() = runTest {
         every { authRepository.getCurrentUserId() } returns "user-123"
         coEvery { authRepository.reauthenticate("password") } returns Result.Success(Unit)
-        every { dataCleanup.stopSyncListeners() } just runs
         coEvery { dataCleanup.deleteCloudData("user-123") } just runs
-        coEvery { authRepository.deleteAccount("password") } returns
-            Result.Error("Firebase Auth error")
+        coEvery { authRepository.deleteAccount() } returns
+            Result.Error("Auth error")
 
         val result = useCase("password")
 
         assertTrue(result is Result.Error)
-        assertEquals("Firebase Auth error", (result as Result.Error).message)
+        val error = result as Result.Error
+        assertTrue(error.message.contains("Your data has been deleted"))
+        assertTrue(error.message.contains("could not remove your account"))
 
         // Cloud data was already deleted (acceptable), but local data should NOT be cleared
-        verify(exactly = 0) { dataCleanup.clearLocalData() }
+        coVerify(exactly = 0) { dataCleanup.clearLocalData() }
     }
 
     // -------------------------------------------------------------------------
@@ -168,10 +165,45 @@ class DeleteAccountUseCaseTest {
     fun `CancellationException is rethrown not wrapped`() = runTest {
         every { authRepository.getCurrentUserId() } returns "user-123"
         coEvery { authRepository.reauthenticate("password") } returns Result.Success(Unit)
-        every { dataCleanup.stopSyncListeners() } just runs
         coEvery { dataCleanup.deleteCloudData("user-123") } throws
             kotlinx.coroutines.CancellationException("Job cancelled")
 
         useCase("password")
+    }
+
+    // -------------------------------------------------------------------------
+    // 7. Auth deletion failure after cloud data deleted: specific recovery msg
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `auth deletion failure after cloud data deleted returns specific recovery message`() = runTest {
+        every { authRepository.getCurrentUserId() } returns "user-123"
+        coEvery { authRepository.reauthenticate("password") } returns Result.Success(Unit)
+        coEvery { dataCleanup.deleteCloudData("user-123") } just runs
+        coEvery { authRepository.deleteAccount() } returns Result.Error("Auth error")
+
+        val result = useCase("password")
+
+        assertTrue(result is Result.Error)
+        val error = result as Result.Error
+        assertTrue(error.message.contains("Your data has been deleted"))
+        assertTrue(error.message.contains("could not remove your account"))
+    }
+
+    // -------------------------------------------------------------------------
+    // 8. clearLocalData failure is best-effort -- still returns success
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `clearLocalData failure still returns success since account is already deleted`() = runTest {
+        every { authRepository.getCurrentUserId() } returns "user-123"
+        coEvery { authRepository.reauthenticate("password") } returns Result.Success(Unit)
+        coEvery { dataCleanup.deleteCloudData("user-123") } just runs
+        coEvery { authRepository.deleteAccount() } returns Result.Success(Unit)
+        coEvery { dataCleanup.clearLocalData() } throws RuntimeException("Room error")
+
+        val result = useCase("password")
+
+        assertTrue(result is Result.Success)
     }
 }

--- a/domain/src/test/kotlin/com/getaltair/kairos/domain/usecase/DeleteAccountUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/getaltair/kairos/domain/usecase/DeleteAccountUseCaseTest.kt
@@ -1,0 +1,177 @@
+package com.getaltair.kairos.domain.usecase
+
+import com.getaltair.kairos.domain.common.Result
+import com.getaltair.kairos.domain.repository.AuthRepository
+import com.getaltair.kairos.domain.sync.DataCleanup
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DeleteAccountUseCaseTest {
+
+    private lateinit var authRepository: AuthRepository
+    private lateinit var dataCleanup: DataCleanup
+    private lateinit var useCase: DeleteAccountUseCase
+
+    @Before
+    fun setup() {
+        authRepository = mockk()
+        dataCleanup = mockk()
+        useCase = DeleteAccountUseCase(authRepository, dataCleanup)
+    }
+
+    // -------------------------------------------------------------------------
+    // 1. Happy path: all steps succeed, Result.Success returned
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `happy path deletes all data and returns success`() = runTest {
+        every { authRepository.getCurrentUserId() } returns "user-123"
+        coEvery { authRepository.reauthenticate("password") } returns Result.Success(Unit)
+        every { dataCleanup.stopSyncListeners() } just runs
+        coEvery { dataCleanup.deleteCloudData("user-123") } just runs
+        coEvery { authRepository.deleteAccount("password") } returns Result.Success(Unit)
+        every { dataCleanup.clearLocalData() } just runs
+
+        val result = useCase("password")
+
+        assertTrue(result is Result.Success)
+
+        // Verify all steps were called in expected order
+        verify(exactly = 1) { authRepository.getCurrentUserId() }
+        coVerify(exactly = 1) { authRepository.reauthenticate("password") }
+        verify(exactly = 1) { dataCleanup.stopSyncListeners() }
+        coVerify(exactly = 1) { dataCleanup.deleteCloudData("user-123") }
+        coVerify(exactly = 1) { authRepository.deleteAccount("password") }
+        verify(exactly = 1) { dataCleanup.clearLocalData() }
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. Not signed in: returns error immediately
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `returns error when user is not signed in (null userId)`() = runTest {
+        every { authRepository.getCurrentUserId() } returns null
+
+        val result = useCase("password")
+
+        assertTrue(result is Result.Error)
+        val error = result as Result.Error
+        assertTrue(error.message.contains("No user is currently signed in"))
+
+        // Nothing else should be called
+        coVerify(exactly = 0) { authRepository.reauthenticate(any()) }
+        verify(exactly = 0) { dataCleanup.stopSyncListeners() }
+        coVerify(exactly = 0) { dataCleanup.deleteCloudData(any()) }
+        coVerify(exactly = 0) { authRepository.deleteAccount(any()) }
+        verify(exactly = 0) { dataCleanup.clearLocalData() }
+    }
+
+    @Test
+    fun `returns error when user is not signed in (empty userId)`() = runTest {
+        every { authRepository.getCurrentUserId() } returns ""
+
+        val result = useCase("password")
+
+        assertTrue(result is Result.Error)
+        val error = result as Result.Error
+        assertTrue(error.message.contains("No user is currently signed in"))
+
+        // Nothing else should be called
+        coVerify(exactly = 0) { authRepository.reauthenticate(any()) }
+        verify(exactly = 0) { dataCleanup.stopSyncListeners() }
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. Re-auth failure: returns error, no data deleted
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `reauth failure returns error without deleting any data`() = runTest {
+        every { authRepository.getCurrentUserId() } returns "user-123"
+        coEvery { authRepository.reauthenticate("wrong-password") } returns
+            Result.Error("Incorrect password")
+
+        val result = useCase("wrong-password")
+
+        assertTrue(result is Result.Error)
+        assertEquals("Incorrect password", (result as Result.Error).message)
+
+        // Data operations must NOT be called
+        verify(exactly = 0) { dataCleanup.stopSyncListeners() }
+        coVerify(exactly = 0) { dataCleanup.deleteCloudData(any()) }
+        coVerify(exactly = 0) { authRepository.deleteAccount(any()) }
+        verify(exactly = 0) { dataCleanup.clearLocalData() }
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. Firestore deletion failure: returns error
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `cloud data deletion failure returns error`() = runTest {
+        every { authRepository.getCurrentUserId() } returns "user-123"
+        coEvery { authRepository.reauthenticate("password") } returns Result.Success(Unit)
+        every { dataCleanup.stopSyncListeners() } just runs
+        coEvery { dataCleanup.deleteCloudData("user-123") } throws
+            RuntimeException("Firestore timeout")
+
+        val result = useCase("password")
+
+        assertTrue(result is Result.Error)
+        val error = result as Result.Error
+        assertTrue(error.message.contains("Account deletion failed"))
+        assertTrue(error.message.contains("Firestore timeout"))
+
+        // Auth deletion and local cleanup should NOT proceed
+        coVerify(exactly = 0) { authRepository.deleteAccount(any()) }
+        verify(exactly = 0) { dataCleanup.clearLocalData() }
+    }
+
+    // -------------------------------------------------------------------------
+    // 5. Auth deletion failure after cloud data deleted: returns error
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `auth deletion failure returns error`() = runTest {
+        every { authRepository.getCurrentUserId() } returns "user-123"
+        coEvery { authRepository.reauthenticate("password") } returns Result.Success(Unit)
+        every { dataCleanup.stopSyncListeners() } just runs
+        coEvery { dataCleanup.deleteCloudData("user-123") } just runs
+        coEvery { authRepository.deleteAccount("password") } returns
+            Result.Error("Firebase Auth error")
+
+        val result = useCase("password")
+
+        assertTrue(result is Result.Error)
+        assertEquals("Firebase Auth error", (result as Result.Error).message)
+
+        // Cloud data was already deleted (acceptable), but local data should NOT be cleared
+        verify(exactly = 0) { dataCleanup.clearLocalData() }
+    }
+
+    // -------------------------------------------------------------------------
+    // 6. CancellationException is rethrown, not wrapped
+    // -------------------------------------------------------------------------
+
+    @Test(expected = kotlinx.coroutines.CancellationException::class)
+    fun `CancellationException is rethrown not wrapped`() = runTest {
+        every { authRepository.getCurrentUserId() } returns "user-123"
+        coEvery { authRepository.reauthenticate("password") } returns Result.Success(Unit)
+        every { dataCleanup.stopSyncListeners() } just runs
+        coEvery { dataCleanup.deleteCloudData("user-123") } throws
+            kotlinx.coroutines.CancellationException("Job cancelled")
+
+        useCase("password")
+    }
+}

--- a/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsScreen.kt
@@ -77,8 +77,9 @@ fun SettingsScreen(
         }
     }
 
-    LaunchedEffect(uiState.accountDeleted) {
-        if (uiState.accountDeleted) {
+    LaunchedEffect(uiState.deletionState) {
+        if (uiState.deletionState is DeletionState.Deleted) {
+            viewModel.onAccountDeletedConsumed()
             onAccountDeleted()
         }
     }
@@ -131,7 +132,7 @@ fun SettingsScreen(
             }
 
             // Loading overlay during account deletion
-            if (uiState.isDeletingAccount) {
+            if (uiState.deletionState is DeletionState.Deleting) {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -168,7 +169,7 @@ fun SettingsScreen(
     }
 
     // Delete account confirmation dialog
-    if (uiState.showDeleteAccountDialog) {
+    if (uiState.deletionState is DeletionState.ConfirmDialog) {
         AlertDialog(
             onDismissRequest = viewModel::onDeleteAccountDismiss,
             title = { Text(text = "Delete account?") },
@@ -194,7 +195,7 @@ fun SettingsScreen(
     }
 
     // Re-authentication dialog for account deletion
-    if (uiState.showReauthDialog) {
+    if (uiState.deletionState is DeletionState.ReauthDialog) {
         var password by remember { mutableStateOf("") }
 
         AlertDialog(
@@ -219,6 +220,7 @@ fun SettingsScreen(
             confirmButton = {
                 TextButton(
                     onClick = { viewModel.deleteAccount(password) },
+                    enabled = password.isNotBlank(),
                     colors = ButtonDefaults.textButtonColors(
                         contentColor = MaterialTheme.colorScheme.error,
                     ),

--- a/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsScreen.kt
@@ -1,7 +1,9 @@
 package com.getaltair.kairos.feature.settings
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -30,6 +32,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -40,9 +43,12 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.getaltair.kairos.domain.sync.SyncState
@@ -56,6 +62,7 @@ fun SettingsScreen(
     onNavigateToLogin: () -> Unit,
     onNavigateToNotificationSettings: () -> Unit = {},
     onNavigateToDashboardScan: () -> Unit = {},
+    onAccountDeleted: () -> Unit = {},
     onBack: () -> Unit = {},
     viewModel: SettingsViewModel = koinViewModel(),
 ) {
@@ -67,6 +74,12 @@ fun SettingsScreen(
         if (errorMessage != null) {
             snackbarHostState.showSnackbar(errorMessage)
             viewModel.clearError()
+        }
+    }
+
+    LaunchedEffect(uiState.accountDeleted) {
+        if (uiState.accountDeleted) {
+            onAccountDeleted()
         }
     }
 
@@ -86,34 +99,48 @@ fun SettingsScreen(
             )
         },
     ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 24.dp),
-            verticalArrangement = Arrangement.spacedBy(24.dp),
-        ) {
-            Spacer(modifier = Modifier.height(8.dp))
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                Spacer(modifier = Modifier.height(8.dp))
 
-            // Account section
-            AccountSection(
-                uiState = uiState,
-                onNavigateToLogin = onNavigateToLogin,
-                onNavigateToDashboardScan = onNavigateToDashboardScan,
-                onSignOutRequest = viewModel::onSignOutRequest,
-                onDeleteAccountRequest = viewModel::onDeleteAccountRequest,
-            )
+                // Account section
+                AccountSection(
+                    uiState = uiState,
+                    onNavigateToLogin = onNavigateToLogin,
+                    onNavigateToDashboardScan = onNavigateToDashboardScan,
+                    onSignOutRequest = viewModel::onSignOutRequest,
+                    onDeleteAccountRequest = viewModel::onDeleteAccountRequest,
+                )
 
-            // Notifications section
-            NotificationsNavSection(
-                onNavigateToNotificationSettings = onNavigateToNotificationSettings,
-            )
+                // Notifications section
+                NotificationsNavSection(
+                    onNavigateToNotificationSettings = onNavigateToNotificationSettings,
+                )
 
-            // Sync section
-            SyncSection(uiState = uiState, onNavigateToLogin = onNavigateToLogin)
+                // Sync section
+                SyncSection(uiState = uiState, onNavigateToLogin = onNavigateToLogin)
 
-            Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
+            // Loading overlay during account deletion
+            if (uiState.isDeletingAccount) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.7f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
         }
     }
 
@@ -160,6 +187,47 @@ fun SettingsScreen(
             },
             dismissButton = {
                 TextButton(onClick = viewModel::onDeleteAccountDismiss) {
+                    Text(text = "Cancel")
+                }
+            },
+        )
+    }
+
+    // Re-authentication dialog for account deletion
+    if (uiState.showReauthDialog) {
+        var password by remember { mutableStateOf("") }
+
+        AlertDialog(
+            onDismissRequest = { viewModel.onReauthDismiss() },
+            title = { Text(text = "Confirm your password") },
+            text = {
+                Column {
+                    Text(
+                        text = "Enter your password to permanently delete your account and all data.",
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    OutlinedTextField(
+                        value = password,
+                        onValueChange = { password = it },
+                        label = { Text(text = "Password") },
+                        visualTransformation = PasswordVisualTransformation(),
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { viewModel.deleteAccount(password) },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
+                    Text(text = "Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.onReauthDismiss() }) {
                     Text(text = "Cancel")
                 }
             },

--- a/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsUiState.kt
@@ -10,5 +10,8 @@ data class SettingsUiState(
     val lastSyncTime: Instant? = null,
     val showDeleteAccountDialog: Boolean = false,
     val showSignOutDialog: Boolean = false,
+    val showReauthDialog: Boolean = false,
+    val isDeletingAccount: Boolean = false,
+    val accountDeleted: Boolean = false,
     val errorMessage: String? = null,
 )

--- a/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsUiState.kt
@@ -3,15 +3,35 @@ package com.getaltair.kairos.feature.settings
 import com.getaltair.kairos.domain.sync.SyncState
 import java.time.Instant
 
+/**
+ * Models the current phase of the account deletion flow.
+ */
+sealed interface DeletionState {
+    /** No deletion flow is active. */
+    data object Idle : DeletionState
+
+    /** User has been asked to confirm they want to delete their account. */
+    data object ConfirmDialog : DeletionState
+
+    /** User is entering their password for re-authentication. */
+    data object ReauthDialog : DeletionState
+
+    /** Deletion is in progress (network calls active). */
+    data object Deleting : DeletionState
+
+    /** Account was successfully deleted. */
+    data object Deleted : DeletionState
+
+    /** Deletion failed with a user-facing message. */
+    data class Failed(val message: String) : DeletionState
+}
+
 data class SettingsUiState(
     val syncState: SyncState = SyncState.NotSignedIn,
     val userEmail: String? = null,
     val isSignedIn: Boolean = false,
     val lastSyncTime: Instant? = null,
-    val showDeleteAccountDialog: Boolean = false,
     val showSignOutDialog: Boolean = false,
-    val showReauthDialog: Boolean = false,
-    val isDeletingAccount: Boolean = false,
-    val accountDeleted: Boolean = false,
+    val deletionState: DeletionState = DeletionState.Idle,
     val errorMessage: String? = null,
 )

--- a/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.getaltair.kairos.domain.common.Result
 import com.getaltair.kairos.domain.repository.AuthState
 import com.getaltair.kairos.domain.sync.SyncStateProvider
+import com.getaltair.kairos.domain.usecase.DeleteAccountUseCase
 import com.getaltair.kairos.domain.usecase.ObserveAuthStateUseCase
 import com.getaltair.kairos.domain.usecase.SignOutUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,6 +19,7 @@ class SettingsViewModel(
     private val syncStateProvider: SyncStateProvider,
     private val observeAuthStateUseCase: ObserveAuthStateUseCase,
     private val signOutUseCase: SignOutUseCase,
+    private val deleteAccountUseCase: DeleteAccountUseCase,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
@@ -94,8 +96,36 @@ class SettingsViewModel(
         _uiState.update {
             it.copy(
                 showDeleteAccountDialog = false,
-                errorMessage = "Account deletion is not yet available.",
+                showReauthDialog = true,
             )
+        }
+    }
+
+    fun onReauthDismiss() {
+        _uiState.update { it.copy(showReauthDialog = false) }
+    }
+
+    fun deleteAccount(password: String) {
+        _uiState.update { it.copy(isDeletingAccount = true, showReauthDialog = false) }
+        viewModelScope.launch {
+            when (val result = deleteAccountUseCase(password)) {
+                is Result.Success -> {
+                    Timber.d("Account deleted successfully")
+                    _uiState.update {
+                        it.copy(isDeletingAccount = false, accountDeleted = true)
+                    }
+                }
+
+                is Result.Error -> {
+                    Timber.e(result.cause, "Failed to delete account: %s", result.message)
+                    _uiState.update {
+                        it.copy(
+                            isDeletingAccount = false,
+                            errorMessage = result.message,
+                        )
+                    }
+                }
+            }
         }
     }
 

--- a/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/getaltair/kairos/feature/settings/SettingsViewModel.kt
@@ -89,47 +89,54 @@ class SettingsViewModel(
     }
 
     fun onDeleteAccountRequest() {
-        _uiState.update { it.copy(showDeleteAccountDialog = true) }
+        _uiState.update { it.copy(deletionState = DeletionState.ConfirmDialog) }
     }
 
     fun onDeleteAccountConfirm() {
-        _uiState.update {
-            it.copy(
-                showDeleteAccountDialog = false,
-                showReauthDialog = true,
-            )
-        }
+        _uiState.update { it.copy(deletionState = DeletionState.ReauthDialog) }
     }
 
     fun onReauthDismiss() {
-        _uiState.update { it.copy(showReauthDialog = false) }
+        _uiState.update { it.copy(deletionState = DeletionState.Idle) }
     }
 
     fun deleteAccount(password: String) {
-        _uiState.update { it.copy(isDeletingAccount = true, showReauthDialog = false) }
+        _uiState.update { it.copy(deletionState = DeletionState.Deleting) }
         viewModelScope.launch {
-            when (val result = deleteAccountUseCase(password)) {
-                is Result.Success -> {
-                    Timber.d("Account deleted successfully")
-                    _uiState.update {
-                        it.copy(isDeletingAccount = false, accountDeleted = true)
+            try {
+                when (val result = deleteAccountUseCase(password)) {
+                    is Result.Success -> {
+                        Timber.d("Account deleted successfully")
+                        _uiState.update { it.copy(deletionState = DeletionState.Deleted) }
+                    }
+
+                    is Result.Error -> {
+                        Timber.e(result.cause, "Failed to delete account: %s", result.message)
+                        _uiState.update {
+                            it.copy(
+                                deletionState = DeletionState.Failed(result.message),
+                                errorMessage = result.message,
+                            )
+                        }
                     }
                 }
-
-                is Result.Error -> {
-                    Timber.e(result.cause, "Failed to delete account: %s", result.message)
-                    _uiState.update {
-                        it.copy(
-                            isDeletingAccount = false,
-                            errorMessage = result.message,
-                        )
-                    }
+            } catch (e: Exception) {
+                Timber.e(e, "Unexpected error during account deletion")
+                _uiState.update {
+                    it.copy(
+                        deletionState = DeletionState.Failed("An unexpected error occurred. Please try again."),
+                        errorMessage = "An unexpected error occurred. Please try again.",
+                    )
                 }
             }
         }
     }
 
     fun onDeleteAccountDismiss() {
-        _uiState.update { it.copy(showDeleteAccountDialog = false) }
+        _uiState.update { it.copy(deletionState = DeletionState.Idle) }
+    }
+
+    fun onAccountDeletedConsumed() {
+        _uiState.update { it.copy(deletionState = DeletionState.Idle) }
     }
 }

--- a/feature/settings/src/test/kotlin/com/getaltair/kairos/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/getaltair/kairos/feature/settings/SettingsViewModelTest.kt
@@ -4,16 +4,18 @@ import com.getaltair.kairos.domain.common.Result
 import com.getaltair.kairos.domain.repository.AuthState
 import com.getaltair.kairos.domain.sync.SyncState
 import com.getaltair.kairos.domain.sync.SyncStateProvider
+import com.getaltair.kairos.domain.usecase.DeleteAccountUseCase
 import com.getaltair.kairos.domain.usecase.ObserveAuthStateUseCase
 import com.getaltair.kairos.domain.usecase.SignOutUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -33,6 +35,7 @@ class SettingsViewModelTest {
     private val syncStateProvider: SyncStateProvider = mockk()
     private val observeAuthStateUseCase: ObserveAuthStateUseCase = mockk()
     private val signOutUseCase: SignOutUseCase = mockk()
+    private val deleteAccountUseCase: DeleteAccountUseCase = mockk()
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
@@ -57,6 +60,7 @@ class SettingsViewModelTest {
         syncStateProvider = syncStateProvider,
         observeAuthStateUseCase = observeAuthStateUseCase,
         signOutUseCase = signOutUseCase,
+        deleteAccountUseCase = deleteAccountUseCase,
     )
 
     // -------------------------------------------------------------------------
@@ -74,6 +78,9 @@ class SettingsViewModelTest {
         assertNull(state.lastSyncTime)
         assertFalse(state.showDeleteAccountDialog)
         assertFalse(state.showSignOutDialog)
+        assertFalse(state.showReauthDialog)
+        assertFalse(state.isDeletingAccount)
+        assertFalse(state.accountDeleted)
         assertNull(state.errorMessage)
     }
 
@@ -167,19 +174,23 @@ class SettingsViewModelTest {
     }
 
     // -------------------------------------------------------------------------
-    // 7. onDeleteAccountConfirm sets not-available errorMessage
+    // 7. onDeleteAccountConfirm shows re-auth dialog
     // -------------------------------------------------------------------------
 
     @Test
-    fun `onDeleteAccountConfirm sets not-available errorMessage`() {
+    fun `onDeleteAccountConfirm shows reauth dialog and hides delete dialog`() {
         viewModel = createViewModel()
 
+        // First show the delete dialog
+        viewModel.onDeleteAccountRequest()
+        assertTrue(viewModel.uiState.value.showDeleteAccountDialog)
+
+        // Confirm deletion, which should transition to reauth dialog
         viewModel.onDeleteAccountConfirm()
 
-        assertEquals(
-            "Account deletion is not yet available.",
-            viewModel.uiState.value.errorMessage,
-        )
+        val state = viewModel.uiState.value
+        assertTrue(state.showReauthDialog)
+        assertFalse(state.showDeleteAccountDialog)
     }
 
     // -------------------------------------------------------------------------
@@ -229,5 +240,101 @@ class SettingsViewModelTest {
         viewModel.onSignOutDismiss()
 
         assertFalse(viewModel.uiState.value.showSignOutDialog)
+    }
+
+    // -------------------------------------------------------------------------
+    // 11. onReauthDismiss sets showReauthDialog to false
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onReauthDismiss sets showReauthDialog to false`() {
+        viewModel = createViewModel()
+
+        // Open the reauth dialog via the normal flow
+        viewModel.onDeleteAccountRequest()
+        viewModel.onDeleteAccountConfirm()
+        assertTrue(viewModel.uiState.value.showReauthDialog)
+
+        // Dismiss it
+        viewModel.onReauthDismiss()
+
+        assertFalse(viewModel.uiState.value.showReauthDialog)
+    }
+
+    // -------------------------------------------------------------------------
+    // 12. deleteAccount success sets accountDeleted to true
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `deleteAccount success sets accountDeleted to true`() = runTest {
+        viewModel = createViewModel()
+        coEvery { deleteAccountUseCase(any()) } returns Result.Success(Unit)
+
+        viewModel.deleteAccount("password123")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.accountDeleted)
+        assertFalse(state.isDeletingAccount)
+        assertNull(state.errorMessage)
+    }
+
+    // -------------------------------------------------------------------------
+    // 13. deleteAccount failure sets errorMessage and isDeletingAccount false
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `deleteAccount failure sets errorMessage and isDeletingAccount false`() = runTest {
+        viewModel = createViewModel()
+        coEvery { deleteAccountUseCase(any()) } returns Result.Error("Incorrect password")
+
+        viewModel.deleteAccount("wrong-password")
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.accountDeleted)
+        assertFalse(state.isDeletingAccount)
+        assertEquals("Incorrect password", state.errorMessage)
+    }
+
+    // -------------------------------------------------------------------------
+    // 14. deleteAccount sets isDeletingAccount true while in progress
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `deleteAccount sets isDeletingAccount true while in progress`() = runTest {
+        // Use StandardTestDispatcher so coroutine does not complete eagerly
+        val standardDispatcher = StandardTestDispatcher()
+        Dispatchers.setMain(standardDispatcher)
+
+        val deferred = CompletableDeferred<Result<Unit>>()
+        coEvery { deleteAccountUseCase(any()) } coAnswers { deferred.await() }
+
+        viewModel = SettingsViewModel(
+            syncStateProvider = syncStateProvider,
+            observeAuthStateUseCase = observeAuthStateUseCase,
+            signOutUseCase = signOutUseCase,
+            deleteAccountUseCase = deleteAccountUseCase,
+        )
+
+        // Advance past init coroutines
+        standardDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.deleteAccount("password123")
+
+        // Advance enough for the launch to start but the deferred is still pending
+        standardDispatcher.scheduler.runCurrent()
+
+        // While in progress, isDeletingAccount should be true
+        assertTrue(viewModel.uiState.value.isDeletingAccount)
+        assertFalse(viewModel.uiState.value.showReauthDialog)
+
+        // Complete the use case
+        deferred.complete(Result.Success(Unit))
+        standardDispatcher.scheduler.advanceUntilIdle()
+
+        // After completion, isDeletingAccount should be false
+        assertFalse(viewModel.uiState.value.isDeletingAccount)
+        assertTrue(viewModel.uiState.value.accountDeleted)
     }
 }

--- a/feature/settings/src/test/kotlin/com/getaltair/kairos/feature/settings/SettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/getaltair/kairos/feature/settings/SettingsViewModelTest.kt
@@ -76,11 +76,8 @@ class SettingsViewModelTest {
         assertNull(state.userEmail)
         assertFalse(state.isSignedIn)
         assertNull(state.lastSyncTime)
-        assertFalse(state.showDeleteAccountDialog)
         assertFalse(state.showSignOutDialog)
-        assertFalse(state.showReauthDialog)
-        assertFalse(state.isDeletingAccount)
-        assertFalse(state.accountDeleted)
+        assertEquals(DeletionState.Idle, state.deletionState)
         assertNull(state.errorMessage)
     }
 
@@ -183,14 +180,12 @@ class SettingsViewModelTest {
 
         // First show the delete dialog
         viewModel.onDeleteAccountRequest()
-        assertTrue(viewModel.uiState.value.showDeleteAccountDialog)
+        assertEquals(DeletionState.ConfirmDialog, viewModel.uiState.value.deletionState)
 
         // Confirm deletion, which should transition to reauth dialog
         viewModel.onDeleteAccountConfirm()
 
-        val state = viewModel.uiState.value
-        assertTrue(state.showReauthDialog)
-        assertFalse(state.showDeleteAccountDialog)
+        assertEquals(DeletionState.ReauthDialog, viewModel.uiState.value.deletionState)
     }
 
     // -------------------------------------------------------------------------
@@ -247,18 +242,18 @@ class SettingsViewModelTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `onReauthDismiss sets showReauthDialog to false`() {
+    fun `onReauthDismiss resets deletionState to Idle`() {
         viewModel = createViewModel()
 
         // Open the reauth dialog via the normal flow
         viewModel.onDeleteAccountRequest()
         viewModel.onDeleteAccountConfirm()
-        assertTrue(viewModel.uiState.value.showReauthDialog)
+        assertEquals(DeletionState.ReauthDialog, viewModel.uiState.value.deletionState)
 
         // Dismiss it
         viewModel.onReauthDismiss()
 
-        assertFalse(viewModel.uiState.value.showReauthDialog)
+        assertEquals(DeletionState.Idle, viewModel.uiState.value.deletionState)
     }
 
     // -------------------------------------------------------------------------
@@ -266,7 +261,7 @@ class SettingsViewModelTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `deleteAccount success sets accountDeleted to true`() = runTest {
+    fun `deleteAccount success sets deletionState to Deleted`() = runTest {
         viewModel = createViewModel()
         coEvery { deleteAccountUseCase(any()) } returns Result.Success(Unit)
 
@@ -274,8 +269,7 @@ class SettingsViewModelTest {
         advanceUntilIdle()
 
         val state = viewModel.uiState.value
-        assertTrue(state.accountDeleted)
-        assertFalse(state.isDeletingAccount)
+        assertEquals(DeletionState.Deleted, state.deletionState)
         assertNull(state.errorMessage)
     }
 
@@ -284,7 +278,7 @@ class SettingsViewModelTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `deleteAccount failure sets errorMessage and isDeletingAccount false`() = runTest {
+    fun `deleteAccount failure sets deletionState to Failed with error message`() = runTest {
         viewModel = createViewModel()
         coEvery { deleteAccountUseCase(any()) } returns Result.Error("Incorrect password")
 
@@ -292,8 +286,7 @@ class SettingsViewModelTest {
         advanceUntilIdle()
 
         val state = viewModel.uiState.value
-        assertFalse(state.accountDeleted)
-        assertFalse(state.isDeletingAccount)
+        assertEquals(DeletionState.Failed("Incorrect password"), state.deletionState)
         assertEquals("Incorrect password", state.errorMessage)
     }
 
@@ -302,7 +295,7 @@ class SettingsViewModelTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `deleteAccount sets isDeletingAccount true while in progress`() = runTest {
+    fun `deleteAccount sets deletionState to Deleting while in progress`() = runTest {
         // Use StandardTestDispatcher so coroutine does not complete eagerly
         val standardDispatcher = StandardTestDispatcher()
         Dispatchers.setMain(standardDispatcher)
@@ -325,16 +318,31 @@ class SettingsViewModelTest {
         // Advance enough for the launch to start but the deferred is still pending
         standardDispatcher.scheduler.runCurrent()
 
-        // While in progress, isDeletingAccount should be true
-        assertTrue(viewModel.uiState.value.isDeletingAccount)
-        assertFalse(viewModel.uiState.value.showReauthDialog)
+        // While in progress, deletionState should be Deleting
+        assertEquals(DeletionState.Deleting, viewModel.uiState.value.deletionState)
 
         // Complete the use case
         deferred.complete(Result.Success(Unit))
         standardDispatcher.scheduler.advanceUntilIdle()
 
-        // After completion, isDeletingAccount should be false
-        assertFalse(viewModel.uiState.value.isDeletingAccount)
-        assertTrue(viewModel.uiState.value.accountDeleted)
+        // After completion, deletionState should be Deleted
+        assertEquals(DeletionState.Deleted, viewModel.uiState.value.deletionState)
+    }
+
+    // -------------------------------------------------------------------------
+    // 15. onAccountDeletedConsumed resets deletionState to Idle
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onAccountDeletedConsumed resets deletionState to Idle`() = runTest {
+        viewModel = createViewModel()
+        coEvery { deleteAccountUseCase(any()) } returns Result.Success(Unit)
+
+        viewModel.deleteAccount("password123")
+        advanceUntilIdle()
+        assertEquals(DeletionState.Deleted, viewModel.uiState.value.deletionState)
+
+        viewModel.onAccountDeletedConsumed()
+        assertEquals(DeletionState.Idle, viewModel.uiState.value.deletionState)
     }
 }

--- a/sync/src/main/kotlin/com/getaltair/kairos/sync/SyncManager.kt
+++ b/sync/src/main/kotlin/com/getaltair/kairos/sync/SyncManager.kt
@@ -124,6 +124,118 @@ class SyncManager(
     }
 
     // ------------------------------------------------------------------
+    // Account deletion
+    // ------------------------------------------------------------------
+
+    /**
+     * Deletes ALL Firestore data for a user, then the user document itself.
+     *
+     * This is used during account deletion to wipe cloud data before the
+     * Firebase Auth account is removed. The method:
+     * 1. Stops all snapshot listeners (prevents callbacks during deletion).
+     * 2. Deletes documents from every subcollection under `users/{userId}`.
+     * 3. For routines, also deletes nested subcollections (habits, variants).
+     * 4. Deletes the user document at `users/{userId}`.
+     *
+     * Firestore batches are limited to 500 operations, so documents are
+     * committed in chunks when a subcollection exceeds that limit.
+     */
+    suspend fun deleteAllUserData(userId: String) {
+        require(userId.isNotBlank()) { "userId must not be blank" }
+
+        Timber.i("Starting full data deletion for user %s", userId)
+        stopListening()
+
+        try {
+            // --- Routines require special handling for nested subcollections ---
+            val routinesPath = FirestoreCollections.routines(userId).value
+            val routineDocs = firestore.collection(routinesPath).get().await().documents
+            Timber.d("Found %d routine(s) to clean up", routineDocs.size)
+
+            for (routineDoc in routineDocs) {
+                val routineId = routineDoc.id
+                // Delete routine_habits subcollection
+                val habitsPath = FirestoreCollections.routineHabits(userId, routineId).value
+                deleteCollection(habitsPath, "routine_habits for routine $routineId")
+                // Delete routine_variants subcollection
+                val variantsPath = FirestoreCollections.routineVariants(userId, routineId).value
+                deleteCollection(variantsPath, "routine_variants for routine $routineId")
+            }
+
+            // --- Delete top-level subcollections ---
+            deleteCollection(
+                FirestoreCollections.habits(userId).value,
+                "habits",
+            )
+            deleteCollection(
+                FirestoreCollections.completions(userId).value,
+                "completions",
+            )
+            deleteCollection(
+                routinesPath,
+                "routines",
+            )
+            deleteCollection(
+                FirestoreCollections.routineExecutions(userId).value,
+                "routine_executions",
+            )
+            deleteCollection(
+                FirestoreCollections.recoverySessions(userId).value,
+                "recovery_sessions",
+            )
+            deleteCollection(
+                FirestoreCollections.preferences(userId).value,
+                "preferences",
+            )
+            deleteCollection(
+                FirestoreCollections.deletions(userId).value,
+                "deletions",
+            )
+
+            // --- Delete the user document itself ---
+            val userDocPath = FirestoreCollections.user(userId).value
+            firestore.document(userDocPath).delete().await()
+            Timber.i("Deleted user document at %s", userDocPath)
+
+            Timber.i("Completed full data deletion for user %s", userId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to delete all user data for %s", userId)
+            throw e
+        }
+    }
+
+    /**
+     * Deletes all documents in a Firestore collection, respecting the
+     * 500-operation batch limit. Documents are fetched and deleted in
+     * batches until the collection is empty.
+     *
+     * @param collectionPath Full Firestore collection path.
+     * @param label Human-readable label for logging.
+     */
+    private suspend fun deleteCollection(collectionPath: String, label: String) {
+        val collectionRef = firestore.collection(collectionPath)
+        var totalDeleted = 0
+
+        while (true) {
+            val snapshot = collectionRef.limit(BATCH_LIMIT.toLong()).get().await()
+            if (snapshot.isEmpty) break
+
+            val batch = firestore.batch()
+            for (doc in snapshot.documents) {
+                batch.delete(doc.reference)
+            }
+            batch.commit().await()
+            totalDeleted += snapshot.size()
+        }
+
+        if (totalDeleted > 0) {
+            Timber.d("Deleted %d document(s) from %s", totalDeleted, label)
+        }
+    }
+
+    // ------------------------------------------------------------------
     // Push operations
     // ------------------------------------------------------------------
 
@@ -1277,5 +1389,10 @@ class SyncManager(
         is com.getaltair.kairos.domain.entity.RecoverySession -> entity.toFirestoreMap()
         is com.getaltair.kairos.domain.entity.UserPreferences -> entity.toFirestoreMap()
         else -> throw IllegalArgumentException("Unknown entity type: ${entity::class.simpleName}")
+    }
+
+    companion object {
+        /** Firestore WriteBatch maximum operations per commit. */
+        private const val BATCH_LIMIT = 500
     }
 }

--- a/sync/src/main/kotlin/com/getaltair/kairos/sync/SyncManager.kt
+++ b/sync/src/main/kotlin/com/getaltair/kairos/sync/SyncManager.kt
@@ -201,7 +201,7 @@ class SyncManager(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.e(e, "Failed to delete all user data for %s", userId)
+            Timber.e(e, "Failed to delete all user data for %s (partial deletion may have occurred)", userId)
             throw e
         }
     }
@@ -218,16 +218,24 @@ class SyncManager(
         val collectionRef = firestore.collection(collectionPath)
         var totalDeleted = 0
 
-        while (true) {
-            val snapshot = collectionRef.limit(BATCH_LIMIT.toLong()).get().await()
-            if (snapshot.isEmpty) break
+        try {
+            while (true) {
+                val snapshot = collectionRef.limit(BATCH_LIMIT.toLong()).get().await()
+                if (snapshot.isEmpty) break
 
-            val batch = firestore.batch()
-            for (doc in snapshot.documents) {
-                batch.delete(doc.reference)
+                val batch = firestore.batch()
+                for (doc in snapshot.documents) {
+                    batch.delete(doc.reference)
+                }
+                batch.commit().await()
+                totalDeleted += snapshot.size()
+                Timber.d("Deleted batch of %d document(s) from %s (total: %d)", snapshot.size(), label, totalDeleted)
             }
-            batch.commit().await()
-            totalDeleted += snapshot.size()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Failed deleting %s after %d document(s) already removed", label, totalDeleted)
+            throw e
         }
 
         if (totalDeleted > 0) {

--- a/sync/src/test/kotlin/com/getaltair/kairos/sync/SyncManagerTest.kt
+++ b/sync/src/test/kotlin/com/getaltair/kairos/sync/SyncManagerTest.kt
@@ -612,6 +612,265 @@ class SyncManagerTest {
     }
 
     // ------------------------------------------------------------------
+    // deleteAllUserData
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `deleteAllUserData happy path deletes all collections and user document`() = runTest {
+        // Mock routines collection (empty -- no nested subcollections to clean)
+        val routinesPath = FirestoreCollections.routines(userId).value
+        val routinesCollection = mockk<CollectionReference>(relaxed = true)
+        val emptyRoutinesSnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { emptyRoutinesSnapshot.documents } returns emptyList()
+        every { firestore.collection(routinesPath) } returns routinesCollection
+        every { routinesCollection.get() } returns Tasks.forResult(emptyRoutinesSnapshot)
+
+        // All other collections return empty snapshots on limit().get()
+        val emptySnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { emptySnapshot.isEmpty } returns true
+        every { emptySnapshot.size() } returns 0
+
+        val genericCollection = mockk<CollectionReference>(relaxed = true)
+        every { firestore.collection(neq(routinesPath)) } returns genericCollection
+        val limitQuery = mockk<com.google.firebase.firestore.Query>(relaxed = true)
+        every { genericCollection.limit(any()) } returns limitQuery
+        every { limitQuery.get() } returns Tasks.forResult(emptySnapshot)
+
+        // Also set up the routinesCollection.limit() for the deleteCollection call on routines
+        val routinesLimitQuery = mockk<com.google.firebase.firestore.Query>(relaxed = true)
+        every { routinesCollection.limit(any()) } returns routinesLimitQuery
+        every { routinesLimitQuery.get() } returns Tasks.forResult(emptySnapshot)
+
+        // Mock user document deletion
+        val userDocPath = FirestoreCollections.user(userId).value
+        val userDocRef = mockk<DocumentReference>(relaxed = true)
+        every { firestore.document(userDocPath) } returns userDocRef
+        every { userDocRef.delete() } returns Tasks.forResult(null)
+
+        syncManager.deleteAllUserData(userId)
+
+        // Verify user document was deleted
+        verify { firestore.document(userDocPath) }
+        verify { userDocRef.delete() }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `deleteAllUserData throws IllegalArgumentException for blank userId`() = runTest {
+        syncManager.deleteAllUserData("")
+    }
+
+    @Test
+    fun `deleteAllUserData cleans up nested routine subcollections`() = runTest {
+        val routineId = "routine-abc"
+        val routinesPath = FirestoreCollections.routines(userId).value
+        val habitsSubPath = FirestoreCollections.routineHabits(userId, routineId).value
+        val variantsSubPath = FirestoreCollections.routineVariants(userId, routineId).value
+
+        // Mock routine doc
+        val routineDocSnapshot = mockk<DocumentSnapshot>(relaxed = true)
+        every { routineDocSnapshot.id } returns routineId
+
+        val routinesSnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { routinesSnapshot.documents } returns listOf(routineDocSnapshot)
+
+        val routinesCollection = mockk<CollectionReference>(relaxed = true)
+        every { firestore.collection(routinesPath) } returns routinesCollection
+        every { routinesCollection.get() } returns Tasks.forResult(routinesSnapshot)
+
+        // Empty snapshots for deleteCollection calls
+        val emptySnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { emptySnapshot.isEmpty } returns true
+        every { emptySnapshot.size() } returns 0
+
+        // For each collection path, mock limit().get() returning empty
+        val setupEmptyCollection = { path: String ->
+            val coll = mockk<CollectionReference>(relaxed = true)
+            val query = mockk<com.google.firebase.firestore.Query>(relaxed = true)
+            every { firestore.collection(path) } returns coll
+            every { coll.limit(any()) } returns query
+            every { query.get() } returns Tasks.forResult(emptySnapshot)
+        }
+
+        setupEmptyCollection(habitsSubPath)
+        setupEmptyCollection(variantsSubPath)
+
+        // Set up routines collection limit for deleteCollection
+        val routinesLimitQuery = mockk<com.google.firebase.firestore.Query>(relaxed = true)
+        every { routinesCollection.limit(any()) } returns routinesLimitQuery
+        every { routinesLimitQuery.get() } returns Tasks.forResult(emptySnapshot)
+
+        // Generic collection for all other paths
+        val genericCollection = mockk<CollectionReference>(relaxed = true)
+        val genericQuery = mockk<com.google.firebase.firestore.Query>(relaxed = true)
+        every {
+            firestore.collection(not(match { it == routinesPath || it == habitsSubPath || it == variantsSubPath }))
+        } returns genericCollection
+        every { genericCollection.limit(any()) } returns genericQuery
+        every { genericQuery.get() } returns Tasks.forResult(emptySnapshot)
+
+        // User doc delete
+        val userDocRef = mockk<DocumentReference>(relaxed = true)
+        every { firestore.document(any()) } returns userDocRef
+        every { userDocRef.delete() } returns Tasks.forResult(null)
+
+        syncManager.deleteAllUserData(userId)
+
+        // Verify that we tried to access the subcollection paths
+        verify { firestore.collection(habitsSubPath) }
+        verify { firestore.collection(variantsSubPath) }
+    }
+
+    @Test
+    fun `deleteAllUserData handles empty collections gracefully`() = runTest {
+        // All collections are empty
+        val emptyRoutinesSnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { emptyRoutinesSnapshot.documents } returns emptyList()
+
+        val emptySnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { emptySnapshot.isEmpty } returns true
+        every { emptySnapshot.size() } returns 0
+
+        val collectionRef = mockk<CollectionReference>(relaxed = true)
+        every { firestore.collection(any()) } returns collectionRef
+        every { collectionRef.get() } returns Tasks.forResult(emptyRoutinesSnapshot)
+        val limitQuery = mockk<com.google.firebase.firestore.Query>(relaxed = true)
+        every { collectionRef.limit(any()) } returns limitQuery
+        every { limitQuery.get() } returns Tasks.forResult(emptySnapshot)
+
+        val userDocRef = mockk<DocumentReference>(relaxed = true)
+        every { firestore.document(any()) } returns userDocRef
+        every { userDocRef.delete() } returns Tasks.forResult(null)
+
+        // Should complete without error
+        syncManager.deleteAllUserData(userId)
+
+        verify { userDocRef.delete() }
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun `deleteAllUserData propagates Firestore failure`() = runTest {
+        // Routines collection fetch fails
+        val routinesPath = FirestoreCollections.routines(userId).value
+        val routinesCollection = mockk<CollectionReference>(relaxed = true)
+        every { firestore.collection(routinesPath) } returns routinesCollection
+        every { routinesCollection.get() } returns Tasks.forException(
+            RuntimeException("Permission denied"),
+        )
+
+        syncManager.deleteAllUserData(userId)
+    }
+
+    @Test(expected = kotlinx.coroutines.CancellationException::class)
+    fun `deleteAllUserData rethrows CancellationException`() = runTest {
+        val routinesPath = FirestoreCollections.routines(userId).value
+        val routinesCollection = mockk<CollectionReference>(relaxed = true)
+        every { firestore.collection(routinesPath) } returns routinesCollection
+        coEvery { routinesCollection.get() } throws
+            kotlinx.coroutines.CancellationException("Job cancelled")
+
+        syncManager.deleteAllUserData(userId)
+    }
+
+    @Test
+    fun `deleteAllUserData handles batch pagination with more than 500 docs`() = runTest {
+        // Mock routines collection (empty)
+        val routinesPath = FirestoreCollections.routines(userId).value
+        val routinesCollection = mockk<CollectionReference>(relaxed = true)
+        val emptyRoutinesSnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { emptyRoutinesSnapshot.documents } returns emptyList()
+        every { firestore.collection(routinesPath) } returns routinesCollection
+        every { routinesCollection.get() } returns Tasks.forResult(emptyRoutinesSnapshot)
+
+        // Create a snapshot with documents for first batch, then empty for second
+        val firstBatchDocs = (1..500).map { i ->
+            mockk<DocumentSnapshot>(relaxed = true) {
+                every { reference } returns mockk(relaxed = true)
+            }
+        }
+        val firstBatchSnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { firstBatchSnapshot.isEmpty } returns false
+        every { firstBatchSnapshot.documents } returns firstBatchDocs
+        every { firstBatchSnapshot.size() } returns 500
+
+        val emptySnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { emptySnapshot.isEmpty } returns true
+        every { emptySnapshot.size() } returns 0
+
+        // habits collection: first call returns 500 docs, second returns empty
+        val habitsPath = FirestoreCollections.habits(userId).value
+        val habitsCollection = mockk<CollectionReference>(relaxed = true)
+        val habitsLimitQuery = mockk<com.google.firebase.firestore.Query>(relaxed = true)
+        every { firestore.collection(habitsPath) } returns habitsCollection
+        every { habitsCollection.limit(any()) } returns habitsLimitQuery
+        every { habitsLimitQuery.get() } returnsMany listOf(
+            Tasks.forResult(firstBatchSnapshot),
+            Tasks.forResult(emptySnapshot),
+        )
+
+        // Batch mock
+        val batchMock = mockk<com.google.firebase.firestore.WriteBatch>(relaxed = true)
+        every { firestore.batch() } returns batchMock
+        every { batchMock.delete(any()) } returns batchMock
+        every { batchMock.commit() } returns Tasks.forResult(null)
+
+        // All other collections return empty
+        val genericCollection = mockk<CollectionReference>(relaxed = true)
+        val genericLimitQuery = mockk<com.google.firebase.firestore.Query>(relaxed = true)
+        every { firestore.collection(not(match { it == routinesPath || it == habitsPath })) } returns genericCollection
+        every { genericCollection.limit(any()) } returns genericLimitQuery
+        every { genericLimitQuery.get() } returns Tasks.forResult(emptySnapshot)
+        every { routinesCollection.limit(any()) } returns mockk<com.google.firebase.firestore.Query>(relaxed = true) {
+            every { get() } returns Tasks.forResult(emptySnapshot)
+        }
+
+        // User doc delete
+        val userDocRef = mockk<DocumentReference>(relaxed = true)
+        every { firestore.document(any()) } returns userDocRef
+        every { userDocRef.delete() } returns Tasks.forResult(null)
+
+        syncManager.deleteAllUserData(userId)
+
+        // batch.commit() should have been called at least once for the 500-doc batch
+        verify(atLeast = 1) { batchMock.commit() }
+    }
+
+    @Test
+    fun `deleteAllUserData stops listeners before deletion`() = runTest {
+        // First start listening so there are active listeners
+        val listenerReg = mockk<com.google.firebase.firestore.ListenerRegistration>(relaxed = true)
+        val collectionRef = mockk<CollectionReference>(relaxed = true)
+        every { firestore.collection(any()) } returns collectionRef
+        every { collectionRef.addSnapshotListener(any()) } returns listenerReg
+
+        syncManager.startListening(userId)
+
+        // Now set up for deleteAllUserData
+        val emptyRoutinesSnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { emptyRoutinesSnapshot.documents } returns emptyList()
+        every { collectionRef.get() } returns Tasks.forResult(emptyRoutinesSnapshot)
+
+        val emptySnapshot = mockk<QuerySnapshot>(relaxed = true)
+        every { emptySnapshot.isEmpty } returns true
+        every { emptySnapshot.size() } returns 0
+
+        val limitQuery = mockk<com.google.firebase.firestore.Query>(relaxed = true)
+        every { collectionRef.limit(any()) } returns limitQuery
+        every { limitQuery.get() } returns Tasks.forResult(emptySnapshot)
+
+        val userDocRef = mockk<DocumentReference>(relaxed = true)
+        every { firestore.document(any()) } returns userDocRef
+        every { userDocRef.delete() } returns Tasks.forResult(null)
+
+        syncManager.deleteAllUserData(userId)
+
+        // Listeners should have been removed (stopListening is called)
+        verify(atLeast = 1) { listenerReg.remove() }
+
+        // After stopListening, syncState should be NotSignedIn
+        assert(syncManager.syncState.value is SyncState.NotSignedIn)
+    }
+
+    // ------------------------------------------------------------------
     // Test helpers
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Implements full account deletion flow required for Google Play compliance
- Re-authenticates the user with their password before any data is touched
- Deletes all Firestore subcollections (`habits`, `completions`, `routines`, `routine_habits`, `routine_variants`, `routine_executions`, `recovery_sessions`, `preferences`, `deletions`) and the user document
- Deletes the Firebase Auth account, then wipes all local Room tables
- Returns user to the today screen with a cleared back stack after deletion
- Introduces `DataCleanup` domain interface to preserve clean architecture (domain cannot depend on `data`/`sync` modules)

## Changes

| Layer | File(s) | Change |
|-------|---------|--------|
| Domain | `AuthRepository` | Add `reauthenticate()` and `deleteAccount()` |
| Domain | `DataCleanup` (new) | Interface abstracting sync/db cleanup |
| Domain | `DeleteAccountUseCase` (new) | 6-step deletion orchestration |
| Data | `AuthRepositoryImpl` | Implement both new methods; handle `FirebaseAuthInvalidCredentialsException` |
| Sync | `SyncManager` | Add `deleteAllUserData()` with batched Firestore deletion (500-doc limit) |
| App | `DataCleanupImpl` (new) | Bridges `DataCleanup` to `SyncManager` + `KairosDatabase` |
| App | `FirebaseModule`, `UseCaseModule` | Wire new types into Koin DI |
| Feature/Settings | `SettingsUiState` | Add `showReauthDialog`, `isDeletingAccount`, `accountDeleted` |
| Feature/Settings | `SettingsViewModel` | Inject use case; add `deleteAccount()`, `onReauthDismiss()` |
| Feature/Settings | `SettingsScreen` | Re-auth password dialog, loading overlay, `onAccountDeleted` callback |
| App | `KairosNavGraph` | Wire `onAccountDeleted` to navigate to today with cleared back stack |

## Tests

- `DeleteAccountUseCaseTest` (7 new tests): happy path, null/empty user, reauth failure, cloud failure, auth failure, `CancellationException` rethrow
- `SettingsViewModelTest` (4 new + 1 updated, 14 total): deletion success/failure/loading, reauth dismiss, reauth dialog shown on confirm
- `KoinModuleCheckTest`: fixed to include `DataCleanup` as an externally-provided type

## Test plan

- [ ] `./gradlew test` passes (306 tasks, 0 failures)
- [ ] `./gradlew :app:assembleDebug` builds successfully
- [ ] On device: tap Delete Account → confirm dialog → password dialog appears
- [ ] Correct password → loading spinner → today screen (signed out)
- [ ] Wrong password → "Incorrect password" error, account intact
- [ ] Back button after deletion is not possible (back stack cleared)